### PR TITLE
Blog: make the articles survive being run through their own linter

### DIFF
--- a/Docs/Blog/PUBLICACION.md
+++ b/Docs/Blog/PUBLICACION.md
@@ -188,8 +188,113 @@ de los seis (video / voz / cola en segundos):
 | 2 — burstiness | 30.0 / 23.1 / 6.9 | 30.0 / 23.7 / 6.3 |
 | 3 — español | 28.0 / 24.3 / 3.7 | 28.0 / 26.5 / 1.5 |
 
-## 6. Notas de publicación
+## 6. ARTÍCULOS — dónde va cada archivo
+
+| Archivo | Plataforma |
+| --- | --- |
+| `signsofai-maker-story.{en,es}.md` | dev.to · Hashnode · Medium (importa el Markdown) |
+| `signsofai-maker-story.{en,es}.html` | WordPress (bloque HTML) · Blogger (vista HTML) |
+
+Las imágenes van embebidas por URL de GitHub, así que **no hay que subir nada** en cada plataforma.
+
+> **Ojo con `canonical_url`.** En el front-matter apunta al demo. Eso está bien si el artículo solo
+> vive en dev.to/Medium, pero si lo publicas **primero en tu blog**, cambia `canonical_url` a la URL
+> de tu blog en las copias de dev.to / Hashnode / Medium. Si no, le estás diciendo a Google que la
+> versión original de tu artículo es la página del demo, y tu propio blog compite consigo mismo.
+
+**Los artículos se auditan a sí mismos.** Cada uno declara su propio puntaje: EN 35/100 · burstiness
+0.83, ES 33/100 · burstiness 0.86. Si editas el texto, vuelve a correr
+`dotnet run --project src/SignsOfAI.Cli -- check Docs/Blog/signsofai-maker-story.en.md` y **ajusta las
+cifras del párrafo**, porque cambiar el artículo cambia su medición. Alguien va a pegar el artículo
+en la herramienta; que los números cuadren es media credibilidad.
+
+## 7. REDES — copy para acompañar el lanzamiento
+
+### X / Twitter (EN)
+```
+Every AI detector I could point students at gives you one number: "87% AI".
+
+A teacher can't accuse on that. A student can't appeal it. A writer can't learn from it.
+
+So I built one that shows the evidence instead. Every tell highlighted, with the fix.
+English + Spanish. Runs in your browser. MIT.
+
+https://peopleworks.github.io/SignsofAI/
+```
+
+### X / Twitter (ES)
+```
+Todos los detectores de IA te dan un número: "87% IA".
+
+Con eso un profesor no puede acusar, un estudiante no puede apelar, y quien escribe no aprende nada.
+
+Construí uno que muestra la evidencia: cada pista resaltada, con su arreglo.
+Inglés y español. En tu navegador. MIT.
+
+https://peopleworks.github.io/SignsofAI/
+```
+
+### LinkedIn (EN)
+```
+"87% AI."
+
+That's what the detectors give a teacher who suspects a student used ChatGPT. It's a number with no
+argument attached — you can't defend it, appeal it, or learn from it. And if the essay was written in
+Spanish, it's often worse than a coin flip, because almost every one of these tools thinks in English
+and translates the rest.
+
+I built the opposite, and I'm giving it away.
+
+Signs of AI Writing highlights the specific tells in a text — overused vocabulary, rhetorical
+crutches, syntactic patterns, and the statistical rhythm of sentence lengths — and for every single
+one it tells you how to fix it. The Spanish rule pack is derived from scratch, not machine-translated.
+It runs 100% in the browser: no account, no upload, documents never leave the device. It also compares
+documents against each other and highlights the passages they share, as evidence a human judges.
+
+Free and open source (MIT), built with .NET 10 and Blazor WebAssembly.
+
+Try it: https://peopleworks.github.io/SignsofAI/
+Code: https://github.com/peopleworks/SignsofAI
+
+It is a heuristic linter, not a verdict machine. That's deliberate. I'd rather be wrong in a way you
+can see than right in a way you can't.
+
+#AI #AcademicIntegrity #EdTech #dotnet #Blazor #OpenSource
+```
+
+### LinkedIn (ES)
+```
+"87% IA."
+
+Eso es lo que un detector le da a un profesor que sospecha que un estudiante usó ChatGPT. Un número
+sin argumento: no se puede defender, ni apelar, ni aprender de él. Y si el ensayo se escribió en
+español, muchas veces acierta menos que lanzar una moneda, porque casi todas esas herramientas piensan
+en inglés y traducen el resto.
+
+Construí lo contrario, y lo regalo.
+
+Signs of AI Writing resalta las pistas concretas de un texto —vocabulario sobreusado, muletillas
+retóricas, patrones sintácticos y el ritmo estadístico del largo de las frases— y por cada una te dice
+cómo arreglarla. El pack de reglas en español está derivado desde cero, no traducido a máquina. Corre
+100% en el navegador: sin cuenta, sin subir nada, los documentos nunca salen del equipo. Además compara
+documentos entre sí y resalta los pasajes que comparten, como evidencia que juzga una persona.
+
+Gratis y de código abierto (MIT), hecho con .NET 10 y Blazor WebAssembly.
+
+Pruébalo: https://peopleworks.github.io/SignsofAI/
+Código: https://github.com/peopleworks/SignsofAI
+
+Es un linter heurístico, no una máquina de veredictos. Es a propósito: prefiero equivocarme de una
+forma que puedas ver, a acertar de una forma que no puedas revisar.
+
+#IA #IntegridadAcadémica #EdTech #DotNet #Blazor #OpenSource
+```
+
+## 8. Notas de publicación
 - Sube el `.srt` de cada video como subtítulos (clave para reproducción sin sonido en Shorts/Reels/TikTok).
 - Cruza los enlaces: el video enlaza al artículo del blog y viceversa; ambos enlazan al demo.
 - YouTube normaliza el audio a ~−14 LUFS; no hace falta retocar niveles.
-- Orden sugerido de lanzamiento: artículo del blog → shorts (goteo diario) → video grande → Show HN / Reddit con las señales ya acumuladas.
+- **Antes de compartir cualquier link del repo**, sube la tarjeta social (Settings → Social preview,
+  `Docs/Blog/social/social-preview.png`). Si no, X/LinkedIn/Slack muestran la tarjeta gris genérica.
+- Orden sugerido de lanzamiento: artículo del blog → redes (arriba) → shorts (goteo diario) → video
+  grande → Show HN / Reddit con las señales ya acumuladas.

--- a/Docs/Blog/signsofai-maker-story.en.html
+++ b/Docs/Blog/signsofai-maker-story.en.html
@@ -94,7 +94,7 @@ footer{margin-top:2.4em;padding-top:1.2em;border-top:1px solid var(--line);color
 
   <hr>
 
-  <p>Most AI detectors are black boxes. You paste a paragraph, a number comes back — "87% AI" — and you're supposed to trust it. A teacher can't act on that. A writer can't learn from it. And if you wrote in Spanish, the number is often worse than a coin flip.</p>
+  <p>Most AI detectors are black boxes. You paste a paragraph, a number comes back ("87% AI") and you're supposed to trust it. A teacher can't act on that. A writer can't learn from it. And if you wrote in Spanish, the number is often worse than a coin flip.</p>
   <p>So I built the opposite. It's called <strong>SignsOfAI</strong>, it's free, it runs 100% in your browser, and for every signal it flags it tells you <em>what</em> the tell is and <em>how to fix it</em>.</p>
   <p>This is the story of how it works and the decisions behind it.</p>
   <figure><img src="https://raw.githubusercontent.com/peopleworks/SignsofAI/main/Docs/screenshots/analyze-live.gif" alt="The score climbing live from 76 to 87 as AI tells accumulate while typing"><figcaption>The score updates as you type. Every highlight comes with a suggested fix.</figcaption></figure>
@@ -102,8 +102,8 @@ footer{margin-top:2.4em;padding-top:1.2em;border-top:1px solid var(--line);color
   <h2>The itch: a score you can't argue with is a score you can't trust</h2>
   <p>Two things bothered me about the detectors everyone links to.</p>
   <p>First, they hide their reasoning. A percentage is not evidence. If a student is accused of using AI, "the tool said 87%" is not something you can defend, appeal, or learn from. The number feels precise and objective. It is neither.</p>
-  <p>Second, they think in English. The research, the training data, the tells — all English. Spanish gets a machine translation of English rules, which misses how AI actually <em>sounds</em> in Spanish: "sumérgete en el vasto mundo de", "cabe destacar que", "no solo… sino también". Half the planet writes in something other than English, and the tools treat that half as an afterthought.</p>
-  <p>I wanted a tool that was <strong>explainable, actionable, and bilingual</strong> — and that never pretended to be a lie detector.</p>
+  <p>Second, they think in English. The research, the training data, the tells: all English. Spanish gets a machine translation of English rules, which misses how AI actually <em>sounds</em> in Spanish: "sumérgete en el vasto mundo de", "cabe destacar que", "no solo… sino también". Half the planet writes in something other than English, and the tools treat that half as an afterthought.</p>
+  <p>I wanted a tool that was <strong>explainable, actionable, and bilingual</strong>, and that never pretended to be a lie detector.</p>
 
   <h2>What it actually does</h2>
   <p>SignsOfAI does two jobs.</p>
@@ -116,13 +116,13 @@ footer{margin-top:2.4em;padding-top:1.2em;border-top:1px solid var(--line);color
   </ul>
   <p>Every flag carries a concrete fix and the reason behind it. It's a linter, not a verdict.</p>
   <figure><img src="https://raw.githubusercontent.com/peopleworks/SignsofAI/main/Docs/screenshots/evidence.png" alt="The annotated text beside the recommendation list"><figcaption>Not &ldquo;87% AI&rdquo;, but which words, why they were flagged, and what to write instead.</figcaption></figure>
-  <p><strong>2. It checks originality.</strong> Drop in two or more documents — a thesis and its sources, or a whole class's submissions — and it highlights the passages they share: verbatim copies, and <em>reworded paraphrases, even across languages</em>. The number you see equals exactly what's highlighted. The evidence <strong>is</strong> the score. A human judges; the tool never accuses.</p>
+  <p><strong>2. It checks originality.</strong> Drop in two or more documents (a thesis and its sources, or a whole class's submissions) and it highlights the passages they share: verbatim copies, and <em>reworded paraphrases, even across languages</em>. The number you see equals exactly what's highlighted. The evidence <strong>is</strong> the score. A human judges; the tool never accuses.</p>
   <figure><img src="https://raw.githubusercontent.com/peopleworks/SignsofAI/main/Docs/screenshots/originality.png" alt="Cohort overlap matrix with the most similar pairs ranked below"><figcaption>A whole class at a glance: every document against every other, then the shared passages themselves.</figcaption></figure>
 
   <h2>The one signal I trust most: burstiness</h2>
   <p>Here's the tell that's hardest to fake and easiest to measure. Humans write with wildly uneven rhythm. A long, winding sentence with three clauses and an aside, then a short one. Then a fragment. Machines don't. Left alone, an LLM settles into a steady 15–25 words per sentence and holds it, paragraph after paragraph.</p>
-  <p>You can quantify that as <strong>burstiness</strong> — the coefficient of variation of sentence length. Human prose usually scores 0.6–0.8. Default LLM output sits at 0.0–0.2. It needs no word list and no model; it's just statistics on sentence lengths. SignsOfAI computes it, shows it as a per-sentence bar chart, and folds it into the score.</p>
-  <blockquote>By the way — this article was written to pass its own linter. Short sentences next to long ones. No <code>tapestry</code>. That's the point.</blockquote>
+  <p>You can quantify that as <strong>burstiness</strong>: the coefficient of variation of sentence length. Human prose usually scores 0.6–0.8. Default LLM output sits at 0.0–0.2. It needs no word list and no model; it's just statistics on sentence lengths. SignsOfAI computes it, shows it as a per-sentence bar chart, and folds it into the score.</p>
+  <blockquote>By the way: I ran this article through its own linter. It scores 35/100. Light signs. Most of the hits are the slop words the text quotes at you, <code>delve</code> and <code>tapestry</code> among them, and burstiness lands at 0.83, comfortably inside human range. The tool showed me where I was drifting and I fixed it. A percentage can't do that.</blockquote>
 
   <h2>Why rules, not a neural net</h2>
   <p>I didn't train a classifier. That was deliberate.</p>
@@ -134,9 +134,9 @@ footer{margin-top:2.4em;padding-top:1.2em;border-top:1px solid var(--line);color
   <p>This is the part no English-only tool can copy by translating a word list.</p>
 
   <h2>The plot twist: turning a competitor into an advantage</h2>
-  <p>A while after launch, I found a project called <em>no-ai-slop</em> — a viral little skill for editing AI writing, thousands of stars. My first reaction was the honest one: <em>they have thousands, I have three.</em></p>
+  <p>A while after launch, I found a project called <em>no-ai-slop</em>, a viral little skill for editing AI writing, thousands of stars. My first reaction was the honest one: <em>they have thousands, I have three.</em></p>
   <p>Then I looked closer. It's a single Markdown file of rules. English only. No score, no statistics, no originality check. It went viral because it was frictionless and rode the "agent skills" wave, not because it was doing something my engine couldn't.</p>
-  <p>So I didn't compete. I <strong>mined its taxonomy</strong> — 20-odd patterns of AI writing — folded them into my rule packs (bilingual, weighted, with evidence), added an em-dash-overuse detector, and shipped my own drop-in skill, <code>/signs-of-ai</code>, that does the same fast edit but hands off to the real engine for a measured verdict. Same wave. Better boat.</p>
+  <p>So I didn't compete. I <strong>mined its taxonomy</strong>, 20-odd patterns of AI writing, and folded them into my rule packs (bilingual, weighted, with evidence), added an em-dash-overuse detector, and shipped my own drop-in skill, <code>/signs-of-ai</code>, that does the same fast edit but hands off to the real engine for a measured verdict. Same wave. Better boat.</p>
   <p>The lesson: when someone's format is winning, you don't need their format. You need their taxonomy and a stronger foundation underneath.</p>
 
   <h2>Try it, break it, extend it</h2>
@@ -148,7 +148,7 @@ footer{margin-top:2.4em;padding-top:1.2em;border-top:1px solid var(--line);color
     <li><strong>MCP server + agent skill:</strong> call the engine from Claude Desktop or any MCP client, or drop <code>/signs-of-ai</code> into your editor.</li>
     <li><strong>Bring your own rules:</strong> paste a banned-word list or a rule-pack JSON; it merges live.</li>
   </ul>
-  <p>If you teach, write, or grade — or you just want your own prose to stop sounding like a machine — give it a paragraph and see what it says. And if you find a tell it misses, the rule packs are two JSON files. Pull requests welcome.</p>
+  <p>If you teach, write, or grade, or you just want your own prose to stop sounding like a machine, give it a paragraph and see what it says. And if you find a tell it misses, the rule packs are two JSON files. Pull requests welcome.</p>
 
   <footer>
     Built by Pedro Hernández — PeopleWorks, Microsoft MVP for .NET. MIT licensed.<br>

--- a/Docs/Blog/signsofai-maker-story.en.md
+++ b/Docs/Blog/signsofai-maker-story.en.md
@@ -10,7 +10,7 @@ lang: en
 
 # I built an AI-writing detector that shows its work — and speaks Spanish
 
-Most AI detectors are black boxes. You paste a paragraph, a number comes back — "87% AI" — and you're supposed to trust it. A teacher can't act on that. A writer can't learn from it. And if you wrote in Spanish, the number is often worse than a coin flip.
+Most AI detectors are black boxes. You paste a paragraph, a number comes back ("87% AI") and you're supposed to trust it. A teacher can't act on that. A writer can't learn from it. And if you wrote in Spanish, the number is often worse than a coin flip.
 
 So I built the opposite. It's called **SignsOfAI**, it's free, it runs 100% in your browser, and for every signal it flags it tells you *what* the tell is and *how to fix it*. Try it: [peopleworks.github.io/SignsofAI](https://peopleworks.github.io/SignsofAI/).
 
@@ -26,9 +26,9 @@ Two things bothered me about the detectors everyone links to.
 
 First, they hide their reasoning. A percentage is not evidence. If a student is accused of using AI, "the tool said 87%" is not something you can defend, appeal, or learn from. The number feels precise and objective. It is neither.
 
-Second, they think in English. The research, the training data, the tells — all English. Spanish gets a machine translation of English rules, which misses how AI actually *sounds* in Spanish: "sumérgete en el vasto mundo de", "cabe destacar que", "no solo… sino también". Half the planet writes in something other than English, and the tools treat that half as an afterthought.
+Second, they think in English. The research, the training data, the tells: all English. Spanish gets a machine translation of English rules, which misses how AI actually *sounds* in Spanish: "sumérgete en el vasto mundo de", "cabe destacar que", "no solo… sino también". Half the planet writes in something other than English, and the tools treat that half as an afterthought.
 
-I wanted a tool that was **explainable, actionable, and bilingual** — and that never pretended to be a lie detector.
+I wanted a tool that was **explainable, actionable, and bilingual**, and that never pretended to be a lie detector.
 
 ## What it actually does
 
@@ -47,7 +47,7 @@ Every flag carries a concrete fix and the reason behind it. It's a linter, not a
 
 *This is the whole argument in one screenshot: not "87% AI", but which words, why they were flagged, and what to write instead.*
 
-**2. It checks originality.** Drop in two or more documents — a thesis and its sources, or a whole class's submissions — and it highlights the passages they share: verbatim copies, and *reworded paraphrases, even across languages*. The number you see equals exactly what's highlighted. The evidence **is** the score. A human judges; the tool never accuses.
+**2. It checks originality.** Drop in two or more documents (a thesis and its sources, or a whole class's submissions) and it highlights the passages they share: verbatim copies, and *reworded paraphrases, even across languages*. The number you see equals exactly what's highlighted. The evidence **is** the score. A human judges; the tool never accuses.
 
 ![Cohort overlap matrix showing which documents share text, with the most similar pairs ranked below](https://raw.githubusercontent.com/peopleworks/SignsofAI/main/Docs/screenshots/originality.png)
 
@@ -57,9 +57,9 @@ Every flag carries a concrete fix and the reason behind it. It's a linter, not a
 
 Here's the tell that's hardest to fake and easiest to measure. Humans write with wildly uneven rhythm. A long, winding sentence with three clauses and an aside, then a short one. Then a fragment. Machines don't. Left alone, an LLM settles into a steady 15–25 words per sentence and holds it, paragraph after paragraph.
 
-You can quantify that as **burstiness** — the coefficient of variation of sentence length. Human prose usually scores 0.6–0.8. Default LLM output sits at 0.0–0.2. It needs no word list and no model; it's just statistics on sentence lengths. SignsOfAI computes it, shows it as a per-sentence bar chart, and folds it into the score.
+You can quantify that as **burstiness**: the coefficient of variation of sentence length. Human prose usually scores 0.6–0.8. Default LLM output sits at 0.0–0.2. It needs no word list and no model; it's just statistics on sentence lengths. SignsOfAI computes it, shows it as a per-sentence bar chart, and folds it into the score.
 
-By the way — this article was written to pass its own linter. Short sentences next to long ones. No `tapestry`. That's the point.
+By the way: I ran this article through its own linter. It scores 35/100. Light signs. Most of the hits are the slop words the text quotes at you, `delve` and `tapestry` among them, and burstiness lands at 0.83, comfortably inside human range. The tool showed me where I was drifting and I fixed it. A percentage can't do that.
 
 ## Why rules, not a neural net
 
@@ -77,11 +77,11 @@ This is the part no English-only tool can copy by translating a word list.
 
 ## The plot twist: turning a competitor into an advantage
 
-A while after launch, I found a project called *no-ai-slop* — a viral little skill for editing AI writing, thousands of stars. My first reaction was the honest one: *they have thousands, I have three.*
+A while after launch, I found a project called *no-ai-slop*, a viral little skill for editing AI writing, thousands of stars. My first reaction was the honest one: *they have thousands, I have three.*
 
 Then I looked closer. It's a single Markdown file of rules. English only. No score, no statistics, no originality check. It went viral because it was frictionless and rode the "agent skills" wave, not because it was doing something my engine couldn't.
 
-So I didn't compete. I **mined its taxonomy** — 20-odd patterns of AI writing — folded them into my rule packs (bilingual, weighted, with evidence), added an em-dash-overuse detector, and shipped my own drop-in skill, `/signs-of-ai`, that does the same fast edit but hands off to the real engine for a measured verdict. Same wave. Better boat.
+So I didn't compete. I **mined its taxonomy**, 20-odd patterns of AI writing, and folded them into my rule packs (bilingual, weighted, with evidence), added an em-dash-overuse detector, and shipped my own drop-in skill, `/signs-of-ai`, that does the same fast edit but hands off to the real engine for a measured verdict. Same wave. Better boat.
 
 The lesson: when someone's format is winning, you don't need their format. You need their taxonomy and a stronger foundation underneath.
 
@@ -95,6 +95,6 @@ SignsOfAI is MIT-licensed and built for the education and .NET communities.
 - **MCP server + agent skill:** call the engine from Claude Desktop or any MCP client, or drop `/signs-of-ai` into your editor.
 - **Bring your own rules:** paste a banned-word list or a rule-pack JSON; it merges live.
 
-If you teach, write, or grade — or you just want your own prose to stop sounding like a machine — give it a paragraph and see what it says. And if you find a tell it misses, the rule packs are two JSON files. Pull requests welcome.
+If you teach, write, or grade, or you just want your own prose to stop sounding like a machine, give it a paragraph and see what it says. And if you find a tell it misses, the rule packs are two JSON files. Pull requests welcome.
 
 *Built by Pedro Hernández — PeopleWorks, Microsoft MVP for .NET. Por y para la comunidad educativa.*

--- a/Docs/Blog/signsofai-maker-story.es.html
+++ b/Docs/Blog/signsofai-maker-story.es.html
@@ -94,7 +94,7 @@ footer{margin-top:2.4em;padding-top:1.2em;border-top:1px solid var(--line);color
 
   <hr>
 
-  <p>Casi todos los detectores de IA son cajas negras. Pegas un párrafo, vuelve un número — "87% IA" — y se supone que confíes. Un profesor no puede actuar con eso. Un escritor no puede aprender de eso. Y si escribiste en español, el número muchas veces es peor que lanzar una moneda.</p>
+  <p>Casi todos los detectores de IA son cajas negras. Pegas un párrafo, vuelve un número ("87% IA") y se supone que confíes. Un profesor no puede actuar con eso. Un escritor no puede aprender de eso. Y si escribiste en español, el número muchas veces es peor que lanzar una moneda.</p>
   <p>Así que construí lo contrario. Se llama <strong>SignsOfAI</strong>, es gratis, corre 100% en tu navegador, y por cada señal que marca te dice <em>cuál</em> es la pista y <em>cómo arreglarla</em>.</p>
   <p>Esta es la historia de cómo funciona y las decisiones detrás.</p>
   <figure><img src="https://raw.githubusercontent.com/peopleworks/SignsofAI/main/Docs/screenshots/analyze-live.gif" alt="El puntaje sube en vivo de 76 a 87 mientras se acumulan las pistas de IA al escribir"><figcaption>El puntaje se actualiza mientras escribes. Cada resaltado trae su sugerencia de arreglo.</figcaption></figure>
@@ -102,8 +102,8 @@ footer{margin-top:2.4em;padding-top:1.2em;border-top:1px solid var(--line);color
   <h2>La comezón: un puntaje que no puedes discutir es un puntaje que no puedes creer</h2>
   <p>Dos cosas me molestaban de los detectores que todo el mundo enlaza.</p>
   <p>Primero, esconden su razonamiento. Un porcentaje no es evidencia. Si acusan a un estudiante de usar IA, "la herramienta dijo 87%" no es algo que puedas defender, apelar o corregir. El número se siente preciso y objetivo. No es ninguna de las dos.</p>
-  <p>Segundo, piensan en inglés. La investigación, los datos de entrenamiento, las pistas — todo en inglés. El español recibe una traducción mecánica de reglas gringas, que se pierde cómo <em>suena</em> de verdad la IA en español: "sumérgete en el vasto mundo de", "cabe destacar que", "no solo… sino también". Media humanidad escribe en otra lengua, y las herramientas tratan a esa mitad como una idea de último minuto.</p>
-  <p>Quería una herramienta <strong>explicable, accionable y bilingüe</strong> — que nunca fingiera ser un detector de mentiras.</p>
+  <p>Segundo, piensan en inglés. La investigación, los datos de entrenamiento, las pistas: todo en inglés. El español recibe una traducción mecánica de reglas gringas, que se pierde cómo <em>suena</em> de verdad la IA en español: "sumérgete en el vasto mundo de", "cabe destacar que", "no solo… sino también". Media humanidad escribe en otra lengua, y las herramientas tratan a esa mitad como una idea de último minuto.</p>
+  <p>Quería una herramienta <strong>explicable, accionable y bilingüe</strong>, que nunca fingiera ser un detector de mentiras.</p>
 
   <h2>Qué hace, en concreto</h2>
   <p>SignsOfAI hace dos trabajos.</p>
@@ -116,13 +116,13 @@ footer{margin-top:2.4em;padding-top:1.2em;border-top:1px solid var(--line);color
   </ul>
   <p>Cada marca trae un arreglo concreto y la razón detrás. Es un linter, no un veredicto.</p>
   <figure><img src="https://raw.githubusercontent.com/peopleworks/SignsofAI/main/Docs/screenshots/evidence.png" alt="El texto anotado junto a la lista de recomendaciones"><figcaption>No &ldquo;87% IA&rdquo;, sino cuáles palabras, por qué se marcaron, y qué escribir en su lugar.</figcaption></figure>
-  <p><strong>2. Revisa originalidad.</strong> Suelta dos o más documentos — una tesis y sus fuentes, o los trabajos de una clase entera — y resalta los pasajes que comparten: copias literales, y <em>paráfrasis reescritas, incluso entre idiomas</em>. El número que ves es exactamente lo que está resaltado. La evidencia <strong>es</strong> el puntaje. Un humano juzga; la herramienta nunca acusa.</p>
+  <p><strong>2. Revisa originalidad.</strong> Suelta dos o más documentos (una tesis y sus fuentes, o los trabajos de una clase entera) y resalta los pasajes que comparten: copias literales, y <em>paráfrasis reescritas, incluso entre idiomas</em>. El número que ves es exactamente lo que está resaltado. La evidencia <strong>es</strong> el puntaje. Un humano juzga; la herramienta nunca acusa.</p>
   <figure><img src="https://raw.githubusercontent.com/peopleworks/SignsofAI/main/Docs/screenshots/originality.png" alt="Matriz de solapamiento de la cohorte con los pares más similares ordenados debajo"><figcaption>Una clase entera de un vistazo: cada documento contra todos los demás, y luego los pasajes compartidos.</figcaption></figure>
 
   <h2>La señal en la que más confío: burstiness</h2>
   <p>Esta es la pista más difícil de falsificar y más fácil de medir. Los humanos escribimos con un ritmo desparejo. Una frase larga, con tres cláusulas y un inciso, y luego una corta. Después un fragmento. Las máquinas no. A su aire, un modelo se acomoda en unas 15 a 25 palabras por frase y ahí se queda, párrafo tras párrafo.</p>
-  <p>Eso se puede cuantificar como <strong>burstiness</strong> — el coeficiente de variación del largo de las frases. La prosa humana suele dar 0.6–0.8. La salida por defecto de un modelo se queda en 0.0–0.2. No necesita lista de palabras ni modelo; es pura estadística sobre los largos de frase. SignsOfAI lo calcula, lo muestra como un gráfico de barras por frase, y lo integra en el puntaje.</p>
-  <blockquote>Por cierto — este artículo se escribió para pasar su propio linter. Frases cortas junto a largas. Ni un <code>tapiz</code>. Ese es el punto.</blockquote>
+  <p>Eso se puede cuantificar como <strong>burstiness</strong>: el coeficiente de variación del largo de las frases. La prosa humana suele dar 0.6–0.8. La salida por defecto de un modelo se queda en 0.0–0.2. No necesita lista de palabras ni modelo; es pura estadística sobre los largos de frase. SignsOfAI lo calcula, lo muestra como un gráfico de barras por frase, y lo integra en el puntaje.</p>
+  <blockquote>Por cierto: pasé este artículo por su propio linter. Da 33/100. Señales leves. Casi todas las marcas son las palabras que el propio texto cita, <code>sumérgete</code> y <code>tapiz</code> entre ellas, y la burstiness queda en 0.86, bien dentro del rango humano. La herramienta me mostró dónde me estaba desviando y lo corregí. Un porcentaje no hace eso.</blockquote>
 
   <h2>Por qué reglas, no una red neuronal</h2>
   <p>No entrené un clasificador. Fue a propósito.</p>
@@ -134,9 +134,9 @@ footer{margin-top:2.4em;padding-top:1.2em;border-top:1px solid var(--line);color
   <p>Esta es la parte que ninguna herramienta solo-inglés puede copiar traduciendo una lista de palabras.</p>
 
   <h2>El giro: convertir a un competidor en ventaja</h2>
-  <p>Un tiempo después del lanzamiento encontré un proyecto llamado <em>no-ai-slop</em> — un skill viral para editar escritura de IA, miles de estrellas. Mi primera reacción fue la honesta: <em>ellos tienen miles, yo tengo tres.</em></p>
+  <p>Un tiempo después del lanzamiento encontré un proyecto llamado <em>no-ai-slop</em>, un skill viral para editar escritura de IA, miles de estrellas. Mi primera reacción fue la honesta: <em>ellos tienen miles, yo tengo tres.</em></p>
   <p>Luego miré de cerca. Es un solo archivo Markdown de reglas. Solo inglés. Sin puntaje, sin estadística, sin revisión de originalidad. Se volvió viral porque no tenía fricción y montó la ola de los "agent skills", no porque hiciera algo que mi motor no pudiera.</p>
-  <p>Así que no competí. <strong>Extraje su taxonomía</strong> — una veintena de patrones de escritura de IA — la metí en mis packs de reglas (bilingües, ponderados, con evidencia), agregué un detector de abuso de guiones largos, y publiqué mi propio skill, <code>/signs-of-ai</code>, que hace la misma edición rápida pero delega al motor real para un veredicto medido. Misma ola. Mejor barco.</p>
+  <p>Así que no competí. <strong>Extraje su taxonomía</strong>, una veintena de patrones de escritura de IA, y la metí en mis packs de reglas (bilingües, ponderados, con evidencia), agregué un detector de abuso de guiones largos, y publiqué mi propio skill, <code>/signs-of-ai</code>, que hace la misma edición rápida pero delega al motor real para un veredicto medido. Misma ola. Mejor barco.</p>
   <p>La lección: cuando el formato de alguien está ganando, no necesitas su formato. Necesitas su taxonomía y un cimiento más fuerte debajo.</p>
 
   <h2>Pruébalo, rómpelo, extiéndelo</h2>
@@ -148,7 +148,7 @@ footer{margin-top:2.4em;padding-top:1.2em;border-top:1px solid var(--line);color
     <li><strong>Servidor MCP + skill de agente:</strong> llama al motor desde Claude Desktop o cualquier cliente MCP, o suelta <code>/signs-of-ai</code> en tu editor.</li>
     <li><strong>Trae tus propias reglas:</strong> pega una lista de palabras vetadas o un rule-pack JSON; se fusiona al vuelo.</li>
   </ul>
-  <p>Si enseñas, escribes o calificas — o solo quieres que tu prosa deje de sonar a máquina — dale un párrafo y mira qué dice. Y si encuentras una pista que se le escapa, los packs de reglas son dos archivos JSON. Los pull requests son bienvenidos.</p>
+  <p>Si enseñas, escribes o calificas, o solo quieres que tu prosa deje de sonar a máquina, dale un párrafo y mira qué dice. Y si encuentras una pista que se le escapa, los packs de reglas son dos archivos JSON. Los pull requests son bienvenidos.</p>
 
   <footer>
     Hecho por Pedro Hernández — PeopleWorks, Microsoft MVP para .NET. Licencia MIT.<br>

--- a/Docs/Blog/signsofai-maker-story.es.md
+++ b/Docs/Blog/signsofai-maker-story.es.md
@@ -10,7 +10,7 @@ lang: es
 
 # Construí un detector de escritura con IA que muestra sus pruebas — y habla español
 
-Casi todos los detectores de IA son cajas negras. Pegas un párrafo, vuelve un número — "87% IA" — y se supone que confíes. Un profesor no puede actuar con eso. Un escritor no puede aprender de eso. Y si escribiste en español, el número muchas veces es peor que lanzar una moneda.
+Casi todos los detectores de IA son cajas negras. Pegas un párrafo, vuelve un número ("87% IA") y se supone que confíes. Un profesor no puede actuar con eso. Un escritor no puede aprender de eso. Y si escribiste en español, el número muchas veces es peor que lanzar una moneda.
 
 Así que construí lo contrario. Se llama **SignsOfAI**, es gratis, corre 100% en tu navegador, y por cada señal que marca te dice *cuál* es la pista y *cómo arreglarla*. Pruébalo: [peopleworks.github.io/SignsofAI](https://peopleworks.github.io/SignsofAI/).
 
@@ -26,9 +26,9 @@ Dos cosas me molestaban de los detectores que todo el mundo enlaza.
 
 Primero, esconden su razonamiento. Un porcentaje no es evidencia. Si acusan a un estudiante de usar IA, "la herramienta dijo 87%" no es algo que puedas defender, apelar o corregir. El número se siente preciso y objetivo. No es ninguna de las dos.
 
-Segundo, piensan en inglés. La investigación, los datos de entrenamiento, las pistas — todo en inglés. El español recibe una traducción mecánica de reglas gringas, que se pierde cómo *suena* de verdad la IA en español: "sumérgete en el vasto mundo de", "cabe destacar que", "no solo… sino también". Media humanidad escribe en otra lengua, y las herramientas tratan a esa mitad como una idea de último minuto.
+Segundo, piensan en inglés. La investigación, los datos de entrenamiento, las pistas: todo en inglés. El español recibe una traducción mecánica de reglas gringas, que se pierde cómo *suena* de verdad la IA en español: "sumérgete en el vasto mundo de", "cabe destacar que", "no solo… sino también". Media humanidad escribe en otra lengua, y las herramientas tratan a esa mitad como una idea de último minuto.
 
-Quería una herramienta **explicable, accionable y bilingüe** — que nunca fingiera ser un detector de mentiras.
+Quería una herramienta **explicable, accionable y bilingüe**, que nunca fingiera ser un detector de mentiras.
 
 ## Qué hace, en concreto
 
@@ -47,7 +47,7 @@ Cada marca trae un arreglo concreto y la razón detrás. Es un linter, no un ver
 
 *Todo el argumento en una captura: no "87% IA", sino cuáles palabras, por qué se marcaron, y qué escribir en su lugar.*
 
-**2. Revisa originalidad.** Suelta dos o más documentos — una tesis y sus fuentes, o los trabajos de una clase entera — y resalta los pasajes que comparten: copias literales, y *paráfrasis reescritas, incluso entre idiomas*. El número que ves es exactamente lo que está resaltado. La evidencia **es** el puntaje. Un humano juzga; la herramienta nunca acusa.
+**2. Revisa originalidad.** Suelta dos o más documentos (una tesis y sus fuentes, o los trabajos de una clase entera) y resalta los pasajes que comparten: copias literales, y *paráfrasis reescritas, incluso entre idiomas*. El número que ves es exactamente lo que está resaltado. La evidencia **es** el puntaje. Un humano juzga; la herramienta nunca acusa.
 
 ![Matriz de solapamiento de la cohorte que muestra qué documentos comparten texto, con los pares más similares ordenados debajo](https://raw.githubusercontent.com/peopleworks/SignsofAI/main/Docs/screenshots/originality.png)
 
@@ -57,9 +57,9 @@ Cada marca trae un arreglo concreto y la razón detrás. Es un linter, no un ver
 
 Esta es la pista más difícil de falsificar y más fácil de medir. Los humanos escribimos con un ritmo desparejo. Una frase larga, con tres cláusulas y un inciso, y luego una corta. Después un fragmento. Las máquinas no. A su aire, un modelo se acomoda en unas 15 a 25 palabras por frase y ahí se queda, párrafo tras párrafo.
 
-Eso se puede cuantificar como **burstiness** — el coeficiente de variación del largo de las frases. La prosa humana suele dar 0.6–0.8. La salida por defecto de un modelo se queda en 0.0–0.2. No necesita lista de palabras ni modelo; es pura estadística sobre los largos de frase. SignsOfAI lo calcula, lo muestra como un gráfico de barras por frase, y lo integra en el puntaje.
+Eso se puede cuantificar como **burstiness**: el coeficiente de variación del largo de las frases. La prosa humana suele dar 0.6–0.8. La salida por defecto de un modelo se queda en 0.0–0.2. No necesita lista de palabras ni modelo; es pura estadística sobre los largos de frase. SignsOfAI lo calcula, lo muestra como un gráfico de barras por frase, y lo integra en el puntaje.
 
-Por cierto — este artículo se escribió para pasar su propio linter. Frases cortas junto a largas. Ni un "tapiz". Ese es el punto.
+Por cierto: pasé este artículo por su propio linter. Da 33/100. Señales leves. Casi todas las marcas son las palabras que el propio texto cita, `sumérgete` y `tapiz` entre ellas, y la burstiness queda en 0.86, bien dentro del rango humano. La herramienta me mostró dónde me estaba desviando y lo corregí. Un porcentaje no hace eso.
 
 ## Por qué reglas, no una red neuronal
 
@@ -77,11 +77,11 @@ Esta es la parte que ninguna herramienta solo-inglés puede copiar traduciendo u
 
 ## El giro: convertir a un competidor en ventaja
 
-Un tiempo después del lanzamiento encontré un proyecto llamado *no-ai-slop* — un skill viral para editar escritura de IA, miles de estrellas. Mi primera reacción fue la honesta: *ellos tienen miles, yo tengo tres.*
+Un tiempo después del lanzamiento encontré un proyecto llamado *no-ai-slop*, un skill viral para editar escritura de IA, miles de estrellas. Mi primera reacción fue la honesta: *ellos tienen miles, yo tengo tres.*
 
 Luego miré de cerca. Es un solo archivo Markdown de reglas. Solo inglés. Sin puntaje, sin estadística, sin revisión de originalidad. Se volvió viral porque no tenía fricción y montó la ola de los "agent skills", no porque hiciera algo que mi motor no pudiera.
 
-Así que no competí. **Extraje su taxonomía** — una veintena de patrones de escritura de IA — la metí en mis packs de reglas (bilingües, ponderados, con evidencia), agregué un detector de abuso de guiones largos, y publiqué mi propio skill, `/signs-of-ai`, que hace la misma edición rápida pero delega al motor real para un veredicto medido. Misma ola. Mejor barco.
+Así que no competí. **Extraje su taxonomía**, una veintena de patrones de escritura de IA, y la metí en mis packs de reglas (bilingües, ponderados, con evidencia), agregué un detector de abuso de guiones largos, y publiqué mi propio skill, `/signs-of-ai`, que hace la misma edición rápida pero delega al motor real para un veredicto medido. Misma ola. Mejor barco.
 
 La lección: cuando el formato de alguien está ganando, no necesitas su formato. Necesitas su taxonomía y un cimiento más fuerte debajo.
 
@@ -95,6 +95,6 @@ SignsOfAI es de licencia MIT y está hecho para la comunidad educativa y la de .
 - **Servidor MCP + skill de agente:** llama al motor desde Claude Desktop o cualquier cliente MCP, o suelta `/signs-of-ai` en tu editor.
 - **Trae tus propias reglas:** pega una lista de palabras vetadas o un rule-pack JSON; se fusiona al vuelo.
 
-Si enseñas, escribes o calificas — o solo quieres que tu prosa deje de sonar a máquina — dale un párrafo y mira qué dice. Y si encuentras una pista que se le escapa, los packs de reglas son dos archivos JSON. Los pull requests son bienvenidos.
+Si enseñas, escribes o calificas, o solo quieres que tu prosa deje de sonar a máquina, dale un párrafo y mira qué dice. Y si encuentras una pista que se le escapa, los packs de reglas son dos archivos JSON. Los pull requests son bienvenidos.
 
 *Hecho por Pedro Hernández — PeopleWorks, Microsoft MVP para .NET. Por y para la comunidad educativa.*


### PR DESCRIPTION
Launch prep. Two things were going to bite us the moment this goes on Hacker News.

### 1. The articles didn't pass their own linter

They claimed to. The English one literally said *"this article was written to pass its own linter... No `tapestry`"* — in an article that quotes `tapestry` as an example of slop. And our own **em-dash rule was firing on both**, at 2.0 per 100 words (26 em-dashes in 1318). The first thing a skeptical reader does is paste the article into the tool.

- Em-dash usage cut roughly in half, in both languages and both formats. The rule no longer fires. Replacements chosen per sentence (periods, colons, parentheses), not mechanically.
- The self-congratulating line is now the actual measurement: **EN 35/100 · burstiness 0.83**, **ES 33/100 · burstiness 0.86**, plus the honest explanation for most of the remaining flags — the article quotes the slop words it warns you about.
- The printed numbers match the CLI exactly. That needed a second pass, because editing a self-referential paragraph changes the score it is reporting.

### 2. `canonical_url` pointed at the demo

Fine if the article only lives on dev.to, wrong if it goes on the blog first: it tells Google the canonical version of the article is the demo page. Documented in `PUBLICACION.md` with the fix.

### Also

Ready-to-paste launch copy for X and LinkedIn, in English and Spanish, plus a per-platform table for which article file goes where, and a reminder to upload the social preview before sharing any repo link.
