### PR TITLE
NuGet: publish all three packages via trusted publishing

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -1,12 +1,23 @@
-# Publish SignsOfAI.Core (library) and SignsOfAI.Cli (dotnet tool) to NuGet.org.
-# Add your NuGet API key as the NUGET_API_KEY repo secret, bump the <Version> in the
-# csproj files, then create a GitHub Release — this packs and pushes both packages.
+# Publish SignsOfAI.Core (library), SignsOfAI.Cli and SignsOfAI.Mcp (dotnet tools) to NuGet.org.
+#
+# No API key: this uses NuGet Trusted Publishing, which trades this workflow's OIDC token for a
+# short-lived key at run time. It requires a policy at nuget.org → Account → Trusted Publishing:
+#
+#   Package Owner: peopleworksservices · Repository Owner: peopleworks
+#   Repository: SignsofAI · Workflow File: nuget.yml
+#
+# To ship a version: bump <Version> in the three csproj files, merge, then publish a GitHub Release
+# tagged v<that version> (e.g. v0.1.0). Tests must pass before anything is pushed.
 name: Publish NuGet
 
 on:
   release:
     types: [published]
   workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # required to obtain the OIDC token for trusted publishing
 
 jobs:
   publish:
@@ -19,10 +30,40 @@ jobs:
         with:
           dotnet-version: "10.0.x"
 
+      # A broken build must never reach NuGet — published versions can't be deleted.
+      - name: Test
+        run: dotnet test -c Release --nologo
+
       - name: Pack
         run: |
           dotnet pack src/SignsOfAI.Core -c Release -o out
-          dotnet pack src/SignsOfAI.Cli -c Release -o out
+          dotnet pack src/SignsOfAI.Cli  -c Release -o out
+          dotnet pack src/SignsOfAI.Mcp  -c Release -o out
+          ls -1 out/
+
+      # Guards the classic footgun: tagging v0.2.0 while the csproj files still say 0.1.0.
+      # --skip-duplicate would swallow that silently and report success.
+      - name: Check the release tag matches the packed version
+        if: github.event_name == 'release'
+        run: |
+          want="${GITHUB_REF_NAME#v}"
+          if ! ls out/*."$want".nupkg >/dev/null 2>&1; then
+            echo "::error::Release is tagged $GITHUB_REF_NAME, but nothing packed as version $want."
+            echo "Bump <Version> in the csproj files to $want, or retag the release."
+            ls -1 out/
+            exit 1
+          fi
+          echo "Tag $GITHUB_REF_NAME matches the packed version $want."
+
+      - name: NuGet login (trusted publishing)
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: peopleworksservices
 
       - name: Push to NuGet
-        run: dotnet nuget push "out/*.nupkg" --api-key "${{ secrets.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+        run: |
+          dotnet nuget push "out/*.nupkg" \
+            --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate

--- a/README.md
+++ b/README.md
@@ -113,15 +113,19 @@ the engine lives in `SignsOfAI.Core` — pure .NET, no browser — the server ju
 The first four run entirely on the machine; the last two disclose that they send text to the server
 (endpoint via the `SIGNSOFAI_API_ENDPOINT` environment variable). Point Claude Desktop at it:
 
+It ships on NuGet as [`SignsOfAI.Mcp`](https://www.nuget.org/packages/SignsOfAI.Mcp), so nothing needs
+building. Point Claude Desktop at it:
+
 ```jsonc
 // %APPDATA%\Claude\claude_desktop_config.json
 { "mcpServers": { "signs-of-ai": {
-  "command": "dotnet",
-  "args": ["…/src/SignsOfAI.Mcp/bin/Release/net10.0/SignsOfAI.Mcp.dll"]
+  "command": "dnx",
+  "args": ["SignsOfAI.Mcp", "--yes"]
 }}}
 ```
 
-It also packs as a global tool (`signsofai-mcp`). See `src/SignsOfAI.Mcp/README.md` for details.
+Or install it as a global tool once — `dotnet tool install --global SignsOfAI.Mcp` — and use
+`"command": "signsofai-mcp"`. See `src/SignsOfAI.Mcp/README.md` for details.
 
 ## 5. Use it as an agent skill — `/signs-of-ai`
 

--- a/src/SignsOfAI.Mcp/README.md
+++ b/src/SignsOfAI.Mcp/README.md
@@ -21,47 +21,56 @@ Built on the official [`ModelContextProtocol`](https://www.nuget.org/packages/Mo
 The first four run **entirely on the machine** — the text never leaves it. The last two **send the text**
 to the SignsOfAI server (their descriptions disclose this); see [Server tools](#server-tools-optional).
 
-## Run it
+## Install
+
+It's on NuGet as [`SignsOfAI.Mcp`](https://www.nuget.org/packages/SignsOfAI.Mcp), a .NET tool. You need
+the [.NET 10 SDK](https://dotnet.microsoft.com/download); nothing else to build.
 
 ```bash
-# From the repo root — for development:
-dotnet run --project src/SignsOfAI.Mcp
+# Run it on demand — no install step:
+dnx SignsOfAI.Mcp --yes
 
-# …or build once and point Claude Desktop at the DLL (see below):
-dotnet build src/SignsOfAI.Mcp -c Release
+# …or install the `signsofai-mcp` command once:
+dotnet tool install --global SignsOfAI.Mcp
 ```
 
-To install as a global command (`signsofai-mcp`):
-
-```bash
-dotnet pack src/SignsOfAI.Mcp -c Release
-dotnet tool install --global --add-source src/SignsOfAI.Mcp/bin/Release SignsOfAI.Mcp
-```
+To hack on it instead, run it straight from the repo: `dotnet run --project src/SignsOfAI.Mcp`.
 
 ## Claude Desktop
 
 Add one of these to `claude_desktop_config.json`
 (Windows: `%APPDATA%\Claude\claude_desktop_config.json`), then restart Claude Desktop.
 
-Using the built DLL:
+```json
+{
+  "mcpServers": {
+    "signs-of-ai": {
+      "command": "dnx",
+      "args": ["SignsOfAI.Mcp", "--yes"]
+    }
+  }
+}
+```
+
+Or, if you installed the global tool:
+
+```json
+{
+  "mcpServers": {
+    "signs-of-ai": { "command": "signsofai-mcp" }
+  }
+}
+```
+
+Working from a clone instead? Point it at the built DLL:
 
 ```json
 {
   "mcpServers": {
     "signs-of-ai": {
       "command": "dotnet",
-      "args": ["C:\\Proyecto\\AI\\SignsofAI\\src\\SignsOfAI.Mcp\\bin\\Release\\net10.0\\SignsOfAI.Mcp.dll"]
+      "args": ["C:\\path\\to\\SignsofAI\\src\\SignsOfAI.Mcp\\bin\\Release\\net10.0\\SignsOfAI.Mcp.dll"]
     }
-  }
-}
-```
-
-Or, if installed as a global tool:
-
-```json
-{
-  "mcpServers": {
-    "signs-of-ai": { "command": "signsofai-mcp" }
   }
 }
 ```


### PR DESCRIPTION
Groundwork for the first public release. **Merge this before creating the trusted-publishing policy on nuget.org** — the policy points at this workflow file.

### What was wrong

`nuget.yml` packed only Core and Cli, and pushed with a `NUGET_API_KEY` secret that was never configured. So nothing had ever shipped — while the root README and the blog article already tell people to run `dotnet tool install --global SignsOfAI.Cli`. That claim goes from false to true the moment this ships.

### What changed

- **Trusted publishing.** The workflow trades its OIDC token for a short-lived key at run time. No secret to store, leak, or renew every 365 days.
- **`SignsOfAI.Mcp` added** to the packed set, so all three ship together.
- **Tests gate the push.** A published NuGet version can never be deleted, only unlisted. A broken build must not reach it.
- **Tag/version mismatch fails the run.** Tagging `v0.2.0` while the csproj files still say `0.1.0` would otherwise be swallowed by `--skip-duplicate` and reported as a green success — you'd think you shipped and you didn't.
- **READMEs tell the truth about installing**: `dnx SignsOfAI.Mcp` or the global tool, instead of "build from source".

Verified locally: Core, Cli and Mcp all pack cleanly at `0.1.0`, and the tag check matches them.

### The policy to create at nuget.org → Account → Trusted Publishing

```
Policy Name:      signsofai-release
Package Owner:    peopleworksservices
Repository Owner: peopleworks
Repository:       SignsofAI
Workflow File:    nuget.yml
Environment:      (leave empty)
```

Then: publish a GitHub Release tagged `v0.1.0` and the workflow does the rest.
