### PR TITLE
MCP: make the manifest publishable to the official registry

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -43,7 +43,7 @@ jobs:
 
       # Guards the classic footgun: tagging v0.2.0 while the csproj files still say 0.1.0.
       # --skip-duplicate would swallow that silently and report success.
-      - name: Check the release tag matches the packed version
+      - name: Check the release tag matches what we built
         if: github.event_name == 'release'
         run: |
           want="${GITHUB_REF_NAME#v}"
@@ -53,7 +53,18 @@ jobs:
             ls -1 out/
             exit 1
           fi
-          echo "Tag $GITHUB_REF_NAME matches the packed version $want."
+
+          # The MCP manifest carries its own version twice, and the MCP registry serves it to
+          # clients. If it drifts, the registry advertises a version that doesn't exist.
+          manifest="src/SignsOfAI.Mcp/.mcp/server.json"
+          server_version=$(jq -r '.version' "$manifest")
+          package_version=$(jq -r '.packages[0].version' "$manifest")
+          if [ "$server_version" != "$want" ] || [ "$package_version" != "$want" ]; then
+            echo "::error::$manifest says version=$server_version, packages[0].version=$package_version — expected $want."
+            exit 1
+          fi
+
+          echo "Tag $GITHUB_REF_NAME matches the packages and the MCP manifest."
 
       - name: NuGet login (trusted publishing)
         id: login

--- a/src/SignsOfAI.Mcp/.mcp/server.json
+++ b/src/SignsOfAI.Mcp/.mcp/server.json
@@ -1,9 +1,9 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.peopleworks/signs-of-ai",
   "version": "0.1.0",
   "title": "Signs of AI Writing",
-  "description": "Explainable AI-writing detection and originality checking in English and Spanish. Returns the evidence behind the score — overused vocabulary, rhetorical crutches, syntactic patterns and sentence-rhythm burstiness — each with a fix, and compares documents against each other to surface shared passages.",
+  "description": "Bilingual (EN/ES) AI-writing detection that shows the evidence, plus originality checking.",
   "packages": [
     {
       "registryType": "nuget",


### PR DESCRIPTION
Prep for the official MCP registry. I ran the registry's own validator against our manifest **before** spending an interactive login on it, and it caught two things that would have failed the publish:

1. **`description` was 290 characters — the registry caps it at 100.** The publish would have errored out right after authenticating. Rewritten to 90 characters, keeping the two differentiators (bilingual, shows the evidence).
2. **The `2025-10-17` schema is deprecated.** Now on `2025-12-11`. That revision only adds URL template variables for *remote* servers, so a stdio server needs no other change — but publishing on a deprecated schema is a bad first impression for a registry entry.

`mcp-publisher validate` now reports **✅ valid**.

### Plus a guard for a drift the release job couldn't see

`.mcp/server.json` carries its own version **twice** (`version` and `packages[0].version`), and the MCP registry serves that to clients. Bump the csproj files without bumping the manifest and the registry advertises a version nobody can install — while the NuGet publish stays green. The release job now fails on that mismatch.

### After merge

The publish itself is interactive OAuth, so it's yours to run:

```
cd src/SignsOfAI.Mcp
mcp-publisher login github
mcp-publisher publish .mcp/server.json
```

`mcp-publisher` v1.8.0 is already installed at `~/.local/bin`. The `io.github.peopleworks/*` namespace is proven by the GitHub login, and the published NuGet package already carries a matching `.mcp/server.json`, which is what the registry checks for ownership.
