### PR TITLE
MCP 0.1.1: prove package ownership to the registry

### DIFF
--- a/src/SignsOfAI.Mcp/.mcp/server.json
+++ b/src/SignsOfAI.Mcp/.mcp/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.peopleworks/signs-of-ai",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "title": "Signs of AI Writing",
   "description": "Bilingual (EN/ES) AI-writing detection that shows the evidence, plus originality checking.",
   "packages": [
@@ -9,7 +9,7 @@
       "registryType": "nuget",
       "registryBaseUrl": "https://api.nuget.org/v3/index.json",
       "identifier": "SignsOfAI.Mcp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/SignsOfAI.Mcp/README.md
+++ b/src/SignsOfAI.Mcp/README.md
@@ -99,3 +99,11 @@ embedding feature enabled on the server.
 
 MCP speaks JSON-RPC over **stdout**, so this server logs everything to **stderr** — never write to stdout
 from a tool.
+
+## MCP registry
+
+Listed in the [official MCP registry](https://registry.modelcontextprotocol.io) under the name below.
+The registry reads that line out of this README to verify that whoever publishes the registry entry also
+owns the NuGet package, so **don't remove or reword it** — publishing would start failing.
+
+mcp-name: io.github.peopleworks/signs-of-ai

--- a/src/SignsOfAI.Mcp/SignsOfAI.Mcp.csproj
+++ b/src/SignsOfAI.Mcp/SignsOfAI.Mcp.csproj
@@ -12,7 +12,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>signsofai-mcp</ToolCommandName>
     <PackageId>SignsOfAI.Mcp</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
     <Authors>Pedro Hernández (PeopleWorks)</Authors>
     <Company>PeopleWorks</Company>
     <Description>Model Context Protocol (MCP) server for Signs of AI Writing. Exposes the engine as tools — analyze text for AI tells, check originality between documents, search the sign catalog, extract distinctive phrases, and (optionally, via the hosted API) measure perplexity and find paraphrases — to Claude Desktop and any MCP client.</Description>


### PR DESCRIPTION
The registry publish got past validation and failed on **ownership**:

> NuGet package 'SignsOfAI.Mcp' ownership validation for version 0.1.0 failed. The server name 'io.github.peopleworks/signs-of-ai' must appear as `mcp-name: io.github.peopleworks/signs-of-ai` in the package README.

That's the registry proving that whoever claims the name also controls the package. NuGet packages are immutable, so it needs a new version.

- **Package README** gets an `MCP registry` section carrying the line, plus a note explaining why it must not be reworded — it looks like decoration, and deleting it would silently break future registry publishes.
- **SignsOfAI.Mcp → 0.1.1**, in the csproj and in *both* places `.mcp/server.json` records a version (the guard added in #10 enforces that they agree).
- **Core and Cli stay at 0.1.0.** Nothing about them changed, and the release job's `--skip-duplicate` handles them.

Verified against the locally packed `SignsOfAI.Mcp.0.1.1.nupkg`: the README inside the package carries the line at line 109, the packed manifest reads `0.1.1` in both spots, and `mcp-publisher validate` passes.

### After merge

I'll cut the `v0.1.1` release so the workflow publishes 0.1.1 to NuGet. Once it indexes, the registry publish is one command again — your login is still valid:

```
cd src/SignsOfAI.Mcp
mcp-publisher publish .mcp/server.json
```
