### PR TITLE
Community: contributing guide, security policy, code of conduct, issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,76 @@
+name: Bug report
+description: Something is broken — a crash, wrong output, or a feature that doesn't work.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For a wrong *score* rather than a broken feature, the false-positive and missed-tell templates
+        will get you a better answer.
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected instead
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open the demo
+        2. Paste …
+        3. Click …
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Where
+      options:
+        - Web app (peopleworks.github.io/SignsofAI)
+        - CLI (SignsOfAI.Cli)
+        - MCP server (SignsOfAI.Mcp)
+        - Library (SignsOfAI.Core)
+        - The /signs-of-ai skill
+        - Self-hosted API
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Package version, or the date if you used the hosted demo.
+      placeholder: "0.1.1"
+    validations:
+      required: false
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser and OS, or .NET SDK version and OS.
+      placeholder: "Edge 141 on Windows 11 / .NET 10.0.100 on Ubuntu 24.04"
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Console output or stack trace
+      description: >
+        Browser console for the web app, terminal output for the CLI. The MCP server logs to stderr.
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Try the live demo first
+    url: https://peopleworks.github.io/SignsofAI/
+    about: Runs entirely in your browser — often the fastest way to check whether something is really a bug.
+  - name: Security vulnerability
+    url: https://github.com/peopleworks/SignsofAI/security/advisories/new
+    about: Report privately, not as a public issue. See SECURITY.md for what counts.
+  - name: How the rules work
+    url: https://github.com/peopleworks/SignsofAI/blob/main/CONTRIBUTING.md
+    about: The rule format, weights, and the calibration invariant — worth a read before proposing a rule.

--- a/.github/ISSUE_TEMPLATE/false-positive.yml
+++ b/.github/ISSUE_TEMPLATE/false-positive.yml
@@ -1,0 +1,63 @@
+name: False positive — it flagged human writing
+description: The linter marked something a person wrote, and it shouldn't have.
+labels: ["false-positive", "rules"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        These are the most valuable reports we get. A tool that cries wolf on ordinary prose is worse
+        than no tool at all, because someone might act on it.
+
+        **Please use text you wrote yourself or a synthetic example.** Don't paste a student's essay,
+        a colleague's draft, or anyone's unpublished writing.
+
+  - type: textarea
+    id: text
+    attributes:
+      label: The text that was flagged
+      description: The sentence or paragraph, not the whole document.
+      placeholder: Paste the smallest piece that still reproduces the flag.
+    validations:
+      required: true
+
+  - type: input
+    id: rule
+    attributes:
+      label: Which rule fired
+      description: The rule id, shown in the finding (for example `lex.delve` or `rhet.not-just`).
+      placeholder: lex.delve
+    validations:
+      required: false
+
+  - type: dropdown
+    id: language
+    attributes:
+      label: Language
+      options:
+        - English
+        - Spanish
+        - Other / mixed
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why this is a false positive
+      description: >
+        What makes this legitimate writing? A technical term of art, a quotation, a domain where the
+        phrase is normal, deliberate style?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Where you saw it
+      options:
+        - Web app (peopleworks.github.io/SignsofAI)
+        - CLI (signsofai check)
+        - MCP server
+        - The /signs-of-ai skill
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/missed-tell.yml
+++ b/.github/ISSUE_TEMPLATE/missed-tell.yml
@@ -1,0 +1,80 @@
+name: Missed tell — propose a rule
+description: AI writing that slips through, or a marker we should be catching.
+labels: ["rules", "enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Rule proposals are welcome from anyone — you don't need to write C#. The rule packs are two
+        JSON files, and we can turn a good example into a rule.
+
+  - type: textarea
+    id: example
+    attributes:
+      label: Example text
+      description: Text a model produced (or a faithful reconstruction) containing the tell.
+      placeholder: Paste the sentence or paragraph.
+    validations:
+      required: true
+
+  - type: input
+    id: tell
+    attributes:
+      label: The tell itself
+      description: The word, phrase or pattern. If it's a pattern, describe its shape.
+      placeholder: e.g. "stands as a testament to" — copula avoidance
+    validations:
+      required: true
+
+  - type: dropdown
+    id: language
+    attributes:
+      label: Language
+      options:
+        - English
+        - Spanish
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Which family does it belong to
+      options:
+        - Lexical — a single overused word
+        - Rhetorical — a crutch, cliché, or hedge
+        - Syntactic — a sentence structure
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: fix
+    attributes:
+      label: What should the writer do instead
+      description: >
+        Every rule ships with a suggestion. A flag with no fix is a black box with extra steps, so
+        this shapes the rule as much as the pattern does.
+      placeholder: e.g. Use "is" — "X is a testament to Y" → "X shows Y".
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence, if you have any
+      description: >
+        A frequency observation, a paper, a corpus, or simply "I've seen four models do this". Not
+        required, but it's what decides the weight the rule gets.
+    validations:
+      required: false
+
+  - type: textarea
+    id: humans
+    attributes:
+      label: Would a human plausibly write this?
+      description: >
+        The hard part of every rule. If careful human writers use this phrase too, say so — it likely
+        means a low weight rather than no rule.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## What this changes
+
+<!-- One or two sentences. If it fixes an issue, link it: Fixes #123 -->
+
+## Why
+
+<!-- The reasoning, not the diff. For a rule change, show the text that was wrongly flagged or wrongly
+     missed — that's the evidence a reviewer needs. -->
+
+## Checklist
+
+- [ ] `dotnet test` passes, with no new build warnings
+- [ ] One idea per PR
+
+If you touched the **rule packs** (`rules.en.json` / `rules.es.json`):
+
+- [ ] The rule carries a `suggestion` — what the writer should do instead
+- [ ] There's a test in `tests/SignsOfAI.Core.Tests` covering it
+- [ ] `CleanHuman` in `ScoringTests` still scores exactly 0 (the new rule doesn't fire on ordinary prose)
+- [ ] Any regex is bounded — no unbounded `.*`; this runs on every keystroke in the browser
+- [ ] Spanish rules are derived from Spanish AI output, not translated from the English pack
+
+If you touched the **articles in `Docs/Blog`**:
+
+- [ ] Re-ran the CLI and updated the scores the articles quote about themselves

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,121 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a
+harassment-free experience for everyone, regardless of age, body size, visible or invisible
+disability, ethnicity, sex characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or
+sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and
+healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the
+  experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit
+  permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## A note specific to this project
+
+This is a tool that can be pointed at people's writing, often students' writing. Please keep that in
+mind here too: **discuss the text, never the author.** Issues and pull requests that quote real
+writing to argue a rule should use anonymized or synthetic examples. Do not paste a student's essay,
+a colleague's draft, or anyone's unpublished work into this repository, and do not use this project
+to accuse a named person of anything.
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior
+and will take appropriate and fair corrective action in response to any behavior that they deem
+inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits,
+code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and
+will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is
+officially representing the community in public spaces. Examples of representing our community include
+using an official email address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community
+leaders responsible for enforcement at **peopleworks@gmail.com**. All complaints will be reviewed and
+investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any
+incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for
+any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or
+unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the
+nature of the violation and an explanation of why the behavior was inappropriate. A public apology
+may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people
+involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified
+period of time. This includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate
+behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the
+community for a specified period of time. No public or private interaction with the people involved,
+including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this
+period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained
+inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes
+of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,149 @@
+# Contributing to Signs of AI Writing
+
+Thanks for being here. This project has one principle, and everything below follows from it:
+
+> **We surface evidence a human can judge. We never hand down a verdict.**
+
+If a change makes the tool more confident but less explainable, it's probably the wrong change.
+
+The most useful contributions are usually **rules** — a tell we miss, or a false positive that punishes
+honest writing. You do not need to know C# to report either one; the
+[issue templates](https://github.com/peopleworks/SignsofAI/issues/new/choose) walk you through it.
+
+## Getting set up
+
+You need the [.NET 10 SDK](https://dotnet.microsoft.com/download). Nothing else.
+
+```bash
+git clone https://github.com/peopleworks/SignsofAI.git
+cd SignsofAI
+dotnet test                              # the whole suite
+dotnet run --project src/SignsOfAI.Web   # the Blazor app, at https://localhost:5001
+dotnet run --project src/SignsOfAI.Cli -- check some-file.md
+```
+
+## The layout
+
+| Project | What it is |
+| --- | --- |
+| `src/SignsOfAI.Core` | The engine. Pure .NET, no browser, no I/O. Everything else is a shell around it. |
+| `src/SignsOfAI.Web` | Blazor WebAssembly app. |
+| `src/SignsOfAI.Cli` | `signsofai` — terminal reports and CI gating. |
+| `src/SignsOfAI.Mcp` | MCP server over stdio. |
+| `src/SignsOfAI.Perplexity.Api` | The optional server for perplexity and paraphrase. |
+| `tests/SignsOfAI.Core.Tests` | xUnit. Every rule change lands with a test here. |
+
+## Adding or changing a rule
+
+Rules live in two JSON files: `src/SignsOfAI.Core/Rules/Packs/rules.en.json` and `rules.es.json`.
+There are two kinds.
+
+**Lexical** — single overused words. All inflections go in `terms`:
+
+```json
+{
+  "id": "lex.delve",
+  "terms": ["delve", "delves", "delving", "delved"],
+  "weight": 6,
+  "severity": "High",
+  "suggestion": "examine, explore, look into, dig into",
+  "evidence": "48× more frequent post-ChatGPT (excess ratio r=28)"
+}
+```
+
+**Pattern** — .NET regex over the text, for rhetorical and syntactic tells:
+
+```json
+{
+  "id": "rhet.not-just",
+  "category": "Rhetorical",
+  "regex": "\\bit'?s not (just|only|merely|about)\\b[^.?!\\n]{1,60}?,\\s*it'?s\\b",
+  "weight": 6,
+  "severity": "High",
+  "message": "Negative parallelism (“it's not just X, it's Y”) — feigns depth.",
+  "suggestion": "State the thing directly."
+}
+```
+
+What we ask of a new rule:
+
+- **A `suggestion` that tells the writer what to do instead.** A flag with no fix is a black box with
+  extra steps. This is not optional.
+- **`evidence` where you have it** — a frequency ratio, a paper, a corpus observation. "It feels
+  AI-ish" is a fine reason to open an issue and a weak reason to merge a rule.
+- **A weight that matches how much the tell actually tells you.** `weight` 1–3 for a word that merely
+  drifted upward, 5–7 for a strong marker, 8–9 for something almost nobody writes by accident.
+  Severity `Info` is for things a human might legitimately want (empty intensifiers like *just*);
+  reserve `High` for real signals.
+- **Bounded regexes.** Prefer `[^.?!\n]{1,60}` over `.*` — the analyzer runs on every keystroke in the
+  browser, and a catastrophic backtrack freezes someone's tab.
+
+### The calibration invariant
+
+`ScoringTests` holds a paragraph called `CleanHuman` and asserts it scores **exactly 0**.
+
+```csharp
+Assert.Equal(0, _a.Analyze(CleanHuman, "en").OverallScore);
+```
+
+**A new rule must not fire on it.** This is the guardrail that keeps the tool from crying wolf on
+ordinary prose, and it is the single easiest test to break — usually by writing a regex that is more
+general than you meant. Run `dotnet test` before you push; if `CleanHuman` moved off 0, tighten the
+rule rather than adjusting the test.
+
+Also note: the **Statistical** category score comes from burstiness alone. A rule you file under
+`Statistical` will show in the findings but won't move the score, which is rarely what you want.
+
+### Spanish is derived, not translated
+
+`rules.es.json` is not a translation of `rules.en.json`, and PRs that machine-translate English rules
+into it will be asked for rework. Spanish AI writing has its own tells (*sumérgete en el vasto mundo
+de*, *cabe destacar que*, *un rico tapiz de*). If you propose a Spanish rule, ground it in Spanish
+text you have actually seen a model produce.
+
+## Tests
+
+Every rule change needs a test in `tests/SignsOfAI.Core.Tests`. The pattern is short:
+
+```csharp
+[Fact]
+public void Flags_negative_parallelism() =>
+    Assert.Contains(_a.Analyze("It's not just a tool, it's a revolution.", "en").Findings,
+                    f => f.RuleId == "rhet.not-just");
+```
+
+`Findings` is an `IReadOnlyList`, so use `.Any(...)` / `Assert.Contains`, not `.Exists(...)`.
+
+## Dogfooding
+
+Run your own prose through the tool before you submit it — including the PR description:
+
+```bash
+dotnet run --project src/SignsOfAI.Cli -- check your-file.md
+```
+
+The blog articles in `Docs/Blog` state their own scores in their own text, and those numbers are
+verified. If you touch them, re-run the CLI and update the figures; editing a self-referential
+paragraph changes the score it reports.
+
+## Pull requests
+
+- One idea per PR. A rule pack change and a UI refactor are two PRs.
+- Say **why**, not just what. If you fixed a false positive, show the sentence that was wrongly flagged.
+- `dotnet test` green, and no new build warnings.
+- Match the surrounding code. The codebase has a voice; comments explain *why*, not *what*.
+
+## Releasing (maintainers)
+
+Bump `<Version>` in the csproj files you're shipping, plus **both** version fields in
+`src/SignsOfAI.Mcp/.mcp/server.json`, then publish a GitHub Release tagged `v<version>`. The workflow
+runs the tests, packs, verifies the tag matches, and publishes to NuGet through trusted publishing —
+there is no API key anywhere.
+
+One landmine: `src/SignsOfAI.Mcp/README.md` contains the line `mcp-name: io.github.peopleworks/signs-of-ai`.
+The MCP registry reads it out of the published package to verify ownership. It looks like decoration.
+It is not. Removing it breaks registry publishing, silently, on the next release.
+
+## Reporting something sensitive
+
+Security issues go through [SECURITY.md](SECURITY.md), not public issues.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Use GitHub's private reporting:
+**[Report a vulnerability](https://github.com/peopleworks/SignsofAI/security/advisories/new)**
+(Security → Advisories → Report a vulnerability). It's private until we publish it together.
+
+Please don't open a public issue for a vulnerability. If GitHub advisories don't work for you, email
+`peopleworks@gmail.com` with `SECURITY` in the subject.
+
+Expect a first reply within a week. This is a small project maintained alongside a day job, so a fix
+may take longer than an acknowledgement — you'll hear where it stands either way. If you'd like credit
+in the advisory, say so; if you'd rather stay anonymous, that's fine too.
+
+## Supported versions
+
+The latest release on NuGet and the deployed web app. There are no long-term support branches.
+
+## What the attack surface actually looks like
+
+Most of this project has no server to attack, which changes what "vulnerability" means here.
+
+| Component | Where it runs | Notes |
+| --- | --- | --- |
+| Web app | Your browser, WebAssembly | Static hosting, no backend, no accounts, no cookies, no analytics. Documents are never uploaded. |
+| `SignsOfAI.Core`, `.Cli`, `.Mcp` | Your machine | Local processing only. |
+| `SignsOfAI.Perplexity.Api` | A server | The only component that receives text — and only from the two features that say so. |
+
+We're especially interested in reports about:
+
+- **Anything that causes text to leave the device from a feature documented as local.** That's the
+  project's central promise; a bug there is the most serious thing you could find.
+- **Credential handling in the optional "Humanize" feature.** Bring-your-own-key credentials are
+  stored in the browser and sent directly to the provider you chose. A path that leaks them anywhere
+  else is a vulnerability.
+- **Catastrophic regex backtracking in the rule packs.** Rules run on every keystroke; a pattern that
+  hangs the tab is a denial of service on the person typing.
+- **Anything in the optional API** — injection, resource exhaustion, or a way to make it return
+  someone else's text.
+
+## What isn't a vulnerability
+
+- **A false positive or a missed tell.** The tool is a heuristic linter, not a verdict machine, and
+  being wrong is a known property, not a security bug. Please file those as regular issues — they're
+  genuinely welcome, just through the other door.
+- **Being able to write text that scores low.** You can, deliberately, and the README says so. The
+  tool measures signals; it doesn't claim to be unfoolable.


### PR DESCRIPTION
GitHub's community checklist was at **3 of 7** (Description, README, License). Two reasons that matters right now: the awesome-list maintainers sitting on our 11 open PRs check that page as a quality signal, and anyone arriving from a directory listing has nowhere to learn how the rules work.

This isn't boilerplate — it documents how the project actually behaves.

### CONTRIBUTING

The part that earns its keep. It covers the two rule formats with real examples lifted from the packs, how to pick a weight and severity, and **the calibration invariant**: `CleanHuman` in `ScoringTests` must keep scoring exactly 0, which is the test a too-general regex breaks first. It also writes down three things that currently live only in our heads:

- Rules filed under **Statistical** show in the findings but don't move the score (it comes from burstiness alone), which is rarely what a contributor wants.
- **Spanish is derived, not translated** — machine-translated English rules will be asked for rework.
- Removing the `mcp-name:` line from the MCP README **silently breaks registry publishing** on the next release. It looks like decoration.

Plus: bounded regexes only, because rules run on every keystroke in the browser and a catastrophic backtrack freezes someone's tab.

### SECURITY

An honest description of an attack surface that is mostly *"there is no server"*. It names what we genuinely want to hear about — text escaping a feature documented as local (that's the project's central promise), BYOK credential leaks in Humanize, catastrophic backtracking, and the optional API — and says plainly that **a false positive is not a vulnerability**, with a pointer to the right door.

### Issue forms

Two are domain-specific: **false positive** and **missed tell**. The missed-tell form asks for the suggested fix and for *"would a human plausibly write this?"*, because those two answers are what turn a report into a mergeable rule. Both warn against pasting a student's or colleague's writing.

### Code of conduct

Contributor Covenant 2.1, plus one clause that belongs to this project specifically: discuss the text, never the author — and don't use this repo to accuse a named person of anything.

Checklist should go to 7 of 7 after merge.
