### PR TITLE
CI: add CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,54 @@
+# CodeQL static analysis for the C# code.
+#
+# Uses build-mode: manual with an explicit `dotnet build` rather than autobuild, because this
+# repository uses the newer .slnx solution format and autobuild's project discovery can miss it.
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Mondays, 06:23 UTC — catches newly published queries against unchanged code.
+    - cron: "23 6 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze C#
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write # to upload the results
+      actions: read
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: csharp
+          build-mode: manual
+          queries: security-and-quality
+
+      - name: Build
+        run: dotnet build SignsOfAI.slnx -c Release --nologo
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:csharp"


### PR DESCRIPTION
Last item on the Security and quality overview. Runs on pushes and PRs to `main`, plus weekly — the schedule matters because CodeQL ships new queries over time, and unchanged code should still get checked against them.

**Two deliberate choices:**

- **`build-mode: manual` with an explicit `dotnet build SignsOfAI.slnx`**, not autobuild. This repo uses the newer `.slnx` solution format, and autobuild's project discovery can miss it — which would analyze nothing and still report a green check. That's the worst kind of security tooling: the one that looks like it's working.
- **`queries: security-and-quality`** rather than the default suite, so it also flags correctness and maintainability patterns, not only vulnerabilities.

Verified the build command locally: `dotnet build SignsOfAI.slnx -c Release` succeeds with 0 warnings, 0 errors, all five projects.

### Also done outside this PR (repo settings)

Your screenshot turned up something I got wrong: **private vulnerability reporting was disabled**, while `SECURITY.md` tells people to report through *"Report a vulnerability"*. That button only existed for you — a researcher would have hit a dead end and might have opened a public issue instead. Enabled now.

**Dependabot alerts** were off too, and they matter more now that we publish to NuGet: if `ModelContextProtocol` or `OnnxRuntime` gets an advisory, everyone who installed `SignsOfAI.Mcp` inherits it. Enabled.
