### PR TITLE
CodeQL: cut the noise from the first run

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,11 @@
+# CodeQL configuration.
+#
+# The build materialises source-generator output (System.Text.Json, the Regex generator, Razor)
+# under obj/. CodeQL will happily analyse it and report on code nobody wrote — 152 of the 227
+# alerts from the first run came from exactly there. Excluding it is the difference between a
+# dashboard someone triages and one everybody ignores.
+name: SignsOfAI CodeQL config
+
+paths-ignore:
+  - "**/obj/**"
+  - "**/bin/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,7 +43,10 @@ jobs:
         with:
           languages: csharp
           build-mode: manual
-          queries: security-and-quality
+          # security-extended, not security-and-quality: the quality suite produced 227 alerts and
+          # not one of them was a security finding, which trains everyone to ignore the tab.
+          queries: security-extended
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Build
         run: dotnet build SignsOfAI.slnx -c Release --nologo


### PR DESCRIPTION
The first CodeQL run opened **227 alerts and not one was a security finding** — 166 warnings, 61 notes, all maintainability. That's my mistake in #13, and it matters: a security tab with 227 untriaged items trains everyone to ignore the tab, which is worse than not having it.

Where they came from:

| Alerts | Where |
| ---: | --- |
| 152 | `obj/**/generated/**` — System.Text.Json and Regex source-generator output |
| 75 | our actual code, all style/maintainability |
| **0** | security |

**Two fixes:**

1. **Exclude `obj/` and `bin/`** through a config file. That code only exists because the workflow builds before analysing — nobody wrote it, and nobody can fix it. 152 alerts gone, none of them information.
2. **`security-extended` instead of `security-and-quality`.** Broader security coverage than the default suite, without the style queries (`cs/useless-cast-to-self`, `cs/linq/missed-where`, `cs/useless-assignment-to-local`) that produced the rest. The build already runs at 0 warnings; C# style is not what we need CodeQL for.

CodeQL closes alerts that stop appearing, so the existing 227 resolve themselves on the next run — no manual triage.

### Separately: that "Add" button on the Community Standards page is a trap

Clicking it opens GitHub's editor **pre-filled with its own boilerplate template** (the `5.1.x / 4.0.x` placeholder table), not our file. Committing that would overwrite the real policy.

Our policy is fine and GitHub does serve it — `https://github.com/peopleworks/SignsofAI/security/policy` returns our actual text, and the Security overview reads "Security policy • Enabled". The Insights row lagging behind is cosmetic.
