### PR TITLE
Web: explain the two web-check paths in a slide-in drawer

### DIFF
--- a/src/SignsOfAI.Web/Components/InfoDrawer.razor
+++ b/src/SignsOfAI.Web/Components/InfoDrawer.razor
@@ -1,0 +1,36 @@
+@* A reusable slide-in explanation panel. Controlled: the parent owns the open state.
+   Usage:
+     <button @onclick="() => _open = true">Explain</button>
+     <InfoDrawer Open="_open" OpenChanged="v => _open = v" Title="…" Icon="lock">…content…</InfoDrawer>
+   It renders a Blazor overlay (never a native browser dialog), so it can't block the extension. *@
+
+@if (Open)
+{
+    <div class="drawer-backdrop" @onclick="Close"></div>
+    <aside class="drawer" role="dialog" aria-modal="true" aria-label="@Title"
+           tabindex="-1" @onkeydown="OnKeyDown">
+        <div class="drawer-head">
+            <h2 class="drawer-title">
+                @if (!string.IsNullOrEmpty(Icon)) { <Icon Name="@Icon" /> }
+                @Title
+            </h2>
+            <button class="icon-btn" title="Close" aria-label="Close" @onclick="Close"><Icon Name="close" /></button>
+        </div>
+        <div class="drawer-body">
+            @ChildContent
+        </div>
+    </aside>
+}
+
+@code {
+    [Parameter] public bool Open { get; set; }
+    [Parameter] public EventCallback<bool> OpenChanged { get; set; }
+    [Parameter] public string Title { get; set; } = "";
+    [Parameter] public string? Icon { get; set; }
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+
+    private Task Close() => OpenChanged.InvokeAsync(false);
+
+    private Task OnKeyDown(KeyboardEventArgs e) =>
+        e.Key == "Escape" ? Close() : Task.CompletedTask;
+}

--- a/src/SignsOfAI.Web/Pages/Originality.razor
+++ b/src/SignsOfAI.Web/Pages/Originality.razor
@@ -56,6 +56,9 @@
                         We can't index the whole web — so instead of guessing, here are this document's most
                         <strong>distinctive passages</strong>. Search each one to see if it already appears online.
                         Nothing is sent anywhere until <em>you</em> click a search. <strong>You judge.</strong>
+                        <button type="button" class="explain-trigger" @onclick="@(() => _showWebHelp = true)">
+                            <Icon Name="lock" /> What happens to your text?
+                        </button>
                     </p>
 
                     @if (_webSearchReady)
@@ -136,6 +139,70 @@
         @if (ReadyCount < 2) { <span class="hint">Add text to at least two documents.</span> }
     </div>
 </section>
+
+<InfoDrawer Open="_showWebHelp" OpenChanged="@(v => _showWebHelp = v)"
+            Title="What happens to your text" Icon="lock">
+    <p class="explain-lead">
+        These web searches are the one place a piece of your document can leave your device. Here is
+        exactly <strong>when</strong> that happens and <strong>where</strong> the text goes — so you can
+        pick the way that fits what you're checking.
+    </p>
+
+    <div class="explain-case">
+        <div class="explain-h">
+            <span class="explain-badge good"><Icon Name="lock" /> Most private</span>
+            <h3>Manual search</h3>
+        </div>
+        <p>You click a <strong>Google</strong>, <strong>Bing</strong> or <strong>DuckDuckGo</strong> link
+           for one passage.</p>
+        <ul class="explain-list">
+            <li><strong>What leaves:</strong> only the passage you clicked, and only when you click it.</li>
+            <li><strong>Where it goes:</strong> straight from your browser to that search engine. It never
+                touches the SignsOfAI server.</li>
+            <li><strong>When it's over:</strong> close the tab and nothing lingers.</li>
+        </ul>
+        <p class="explain-fit">Best for <strong>unpublished work</strong> — a thesis, a manuscript, a
+           draft you don't want sitting in anyone else's logs.</p>
+    </div>
+
+    <div class="explain-case">
+        <div class="explain-h">
+            @if (_webSearchReady)
+            {
+                <span class="explain-badge notice"><Icon Name="globe" /> Convenient · enabled here</span>
+            }
+            else
+            {
+                <span class="explain-badge muted"><Icon Name="globe" /> Not enabled on this server</span>
+            }
+            <h3>Automatic search</h3>
+        </div>
+        <p>One button searches <em>every</em> distinctive passage for you and lists the matches in one place.</p>
+        <ul class="explain-list">
+            <li><strong>What leaves:</strong> all of the distinctive passages (up to 8), the moment you
+                press the button — no per-passage click.</li>
+            <li><strong>Where it goes:</strong> your browser → the SignsOfAI server → the
+                <strong>Brave Search</strong> API. Two hops off your machine instead of one.</li>
+            <li><strong>When:</strong> automatically, as one batch.</li>
+        </ul>
+        <p class="explain-fit">Faster when you're checking many passages or presenting live. Because it
+           sends passages out for you, prefer the manual path for <strong>someone else's</strong>
+           unpublished writing unless they're fine with it.</p>
+        @if (!_webSearchReady)
+        {
+            <p class="explain-note">
+                <Icon Name="alert" /> Automatic search isn't switched on for this server, so you'll only
+                see the manual links below — and they find exactly the same thing.
+            </p>
+        }
+    </div>
+
+    <p class="explain-bottom">
+        <Icon Name="check-circle" />
+        <span><strong>Both find the same thing</strong> — pages that contain your passage word-for-word.
+        The only difference is who does the clicking, and how much text leaves your device to get there.</span>
+    </p>
+</InfoDrawer>
 
 @if (_report is not null)
 {
@@ -397,6 +464,7 @@
     private bool _embeddingAvailable;
     private string? _embeddingModel;
     private bool _webSearchReady;
+    private bool _showWebHelp;          // the "what happens to your text" explainer drawer
     private string _paraState = "idle"; // idle | running | done | error
     private List<ParaphraseMatch> _paraMatches = new();
     private int _paraLiteralExcluded;

--- a/src/SignsOfAI.Web/wwwroot/css/app.css
+++ b/src/SignsOfAI.Web/wwwroot/css/app.css
@@ -670,3 +670,85 @@ button.ghost.sm { padding: .35rem .7rem; font-size: .82rem; }
     .orig-pair .orig-bar { grid-column: 1 / -1; order: 3; }
     .orig-side-by-side { grid-template-columns: 1fr; }
 }
+
+/* ── InfoDrawer (reusable slide-in explanation panel) ──────────────────────── */
+.explain-trigger {
+    display: inline-flex; align-items: center; gap: .3rem;
+    margin-left: .5rem; padding: .1rem .25rem;
+    background: none; border: none; cursor: pointer;
+    color: var(--brand); font: inherit; font-size: .82rem; font-weight: 600;
+    border-bottom: 1px solid transparent;
+}
+.explain-trigger:hover { border-bottom-color: currentColor; }
+.explain-trigger svg { width: .9em; height: .9em; }
+
+.drawer-backdrop {
+    position: fixed; inset: 0; z-index: 1200;
+    background: rgba(0, 0, 0, .45);
+    backdrop-filter: blur(2px);
+    animation: drawer-fade .18s ease-out;
+}
+.drawer {
+    position: fixed; top: 0; right: 0; bottom: 0; z-index: 1201;
+    width: min(440px, 92vw);
+    background: var(--surface); border-left: 1px solid var(--border);
+    box-shadow: -8px 0 32px rgba(0, 0, 0, .18);
+    display: flex; flex-direction: column;
+    animation: drawer-in .22s cubic-bezier(.2, .8, .2, 1);
+    overflow: hidden;
+}
+@keyframes drawer-fade { from { opacity: 0; } to { opacity: 1; } }
+@keyframes drawer-in { from { transform: translateX(100%); } to { transform: translateX(0); } }
+@media (prefers-reduced-motion: reduce) {
+    .drawer, .drawer-backdrop { animation: none; }
+}
+
+.drawer-head {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 1rem 1.1rem; border-bottom: 1px solid var(--border); flex: 0 0 auto;
+}
+.drawer-title {
+    display: flex; align-items: center; gap: .5rem;
+    margin: 0; font-size: 1.05rem; line-height: 1.2;
+}
+.drawer-title svg { width: 1.1em; height: 1.1em; color: var(--brand); }
+.drawer-body { padding: 1.1rem; overflow-y: auto; }
+
+.explain-lead { margin: 0 0 1.1rem; color: var(--text); font-size: .92rem; line-height: 1.55; }
+
+.explain-case {
+    border: 1px solid var(--border); border-radius: 12px;
+    padding: .85rem .95rem; margin-bottom: .9rem; background: var(--surface-2);
+}
+.explain-h { display: flex; flex-direction: column; gap: .35rem; margin-bottom: .5rem; }
+.explain-h h3 { margin: 0; font-size: 1rem; }
+.explain-badge {
+    align-self: flex-start;
+    display: inline-flex; align-items: center; gap: .3rem;
+    padding: .15rem .5rem; border-radius: 999px;
+    font-size: .72rem; font-weight: 700; letter-spacing: .01em;
+    border: 1px solid transparent;
+}
+.explain-badge svg { width: .9em; height: .9em; }
+.explain-badge.good   { color: var(--good);   background: color-mix(in srgb, var(--good) 14%, transparent);   border-color: color-mix(in srgb, var(--good) 35%, transparent); }
+.explain-badge.notice { color: var(--notice); background: color-mix(in srgb, var(--notice) 16%, transparent); border-color: color-mix(in srgb, var(--notice) 38%, transparent); }
+.explain-badge.muted  { color: var(--text-muted); background: var(--surface); border-color: var(--border); }
+
+.explain-case p { margin: .4rem 0; font-size: .88rem; line-height: 1.5; color: var(--text); }
+.explain-list { margin: .5rem 0; padding-left: 1.1rem; display: flex; flex-direction: column; gap: .35rem; }
+.explain-list li { font-size: .86rem; line-height: 1.45; color: var(--text); }
+.explain-fit { color: var(--text-muted); }
+.explain-note {
+    display: flex; align-items: flex-start; gap: .4rem;
+    margin-top: .6rem; padding: .5rem .6rem; border-radius: 9px;
+    background: color-mix(in srgb, var(--notice) 12%, transparent);
+    color: var(--text); font-size: .84rem;
+}
+.explain-note svg { width: 1em; height: 1em; flex: 0 0 auto; margin-top: .15rem; color: var(--notice); }
+
+.explain-bottom {
+    display: flex; align-items: flex-start; gap: .45rem;
+    margin: 1rem 0 0; padding-top: .9rem; border-top: 1px solid var(--border);
+    font-size: .9rem; line-height: 1.5; color: var(--text);
+}
+.explain-bottom svg { width: 1.1em; height: 1.1em; flex: 0 0 auto; margin-top: .15rem; color: var(--good); }


### PR DESCRIPTION
A real user (a student, on their thesis) ran the originality web-check and wasn't sure what *"nothing is sent until you click"* meant, or what turning on the automatic option would change. That manual-vs-automatic choice is precisely where someone checking **unpublished** writing needs to know where their text goes — and the UI didn't explain it.

This adds an in-app explanation at that exact moment, as a reusable pattern.

### New `InfoDrawer` component

A controlled, right-side slide-in panel: backdrop, close on button / backdrop / Esc, entrance animation that respects `prefers-reduced-motion`. It renders a **Blazor overlay, never a native browser dialog**, so it can't block the page. Built generic (`Title`, `Icon`, child content) so we can drop the same "explain this decision" aside anywhere else later.

### The web-check explainer

A subtle **"What happens to your text?"** link in the web-check hint opens the drawer, which lays out both paths honestly:

- **Manual search** — badge *Most private*. Only the passage you clicked, only when you click, straight to the search engine, never touching our server. Best for unpublished work.
- **Automatic search** — where the text actually goes: *browser → SignsOfAI server → Brave Search*, all passages as one batch. The badge adapts: *"enabled here"* when the operator turned it on, *"Not enabled on this server"* otherwise (with a note that you'll just see the manual links, which find the same thing).
- Bottom line: **both find the same thing** — the only difference is how much text leaves your device.

It names the case that prompted this: prefer the manual path for **someone else's** unpublished writing unless they're fine with it.

### Verified

Light and dark themes (screenshots taken against a local build), backdrop-close works, the layout holds when auto search is off (the real state of the current server). `dotnet build` 0 warnings, **75/75 tests pass**.

*Separately, from the same conversation: the deployed server is live with perplexity and paraphrase ready but `webSearchReady: false`. Turning on automatic search is an operator step (a Brave API key in `BRAVE_API_KEY`), not part of this PR.*
