### PR TITLE
README: add CodeGuilds listing badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![NuGet Core](https://img.shields.io/nuget/v/SignsOfAI.Core?logo=nuget&label=Core)](https://www.nuget.org/packages/SignsOfAI.Core)
 [![NuGet CLI](https://img.shields.io/nuget/v/SignsOfAI.Cli?logo=nuget&label=CLI)](https://www.nuget.org/packages/SignsOfAI.Cli)
 [![NuGet MCP](https://img.shields.io/nuget/v/SignsOfAI.Mcp?logo=nuget&label=MCP%20server)](https://www.nuget.org/packages/SignsOfAI.Mcp)
+[![Available on CodeGuilds](https://img.shields.io/badge/Available_on-CodeGuilds-6366f1?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0id2hpdGUiIGQ9Ik0xMiAyTDIgN2wxMCA1IDEwLTV6TTIgMTdsMTAgNSAxMC01TTIgMTJsMTAgNSAxMC01Ii8+PC9zdmc+)](https://codeguilds.dev/packages/signsofai)
 
 **[Try the live demo &rarr;](https://peopleworks.github.io/SignsofAI/)** — English & Spanish, runs 100% in your browser. No signup, and nothing leaves your device.
 


### PR DESCRIPTION
SignsofAI was imported into codeguilds.dev from the MCP registry and the listing is now claimed, so link it from the distribution badge row next to the three NuGet packages.

## What this changes

<!-- One or two sentences. If it fixes an issue, link it: Fixes #123 -->

## Why

<!-- The reasoning, not the diff. For a rule change, show the text that was wrongly flagged or wrongly
     missed — that's the evidence a reviewer needs. -->

## Checklist

- [ ] `dotnet test` passes, with no new build warnings
- [ ] One idea per PR

If you touched the **rule packs** (`rules.en.json` / `rules.es.json`):

- [ ] The rule carries a `suggestion` — what the writer should do instead
- [ ] There's a test in `tests/SignsOfAI.Core.Tests` covering it
- [ ] `CleanHuman` in `ScoringTests` still scores exactly 0 (the new rule doesn't fire on ordinary prose)
- [ ] Any regex is bounded — no unbounded `.*`; this runs on every keystroke in the browser
- [ ] Spanish rules are derived from Spanish AI output, not translated from the English pack

If you touched the **articles in `Docs/Blog`**:

- [ ] Re-ran the CLI and updated the scores the articles quote about themselves
