### PR TITLE
Meet the .NET Foundation eligibility criteria

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,0 +1,108 @@
+# Build the Windows desktop app and attach it to a `desktop-v*` GitHub Release.
+#
+# Until this existed, the zip on desktop-v0.1.0 was produced on a developer machine. That is the
+# one thing the .NET Foundation "identical deployable artifacts" criterion does not tolerate: an
+# artifact nobody else can reproduce. Everything the release carries is now built here, from the
+# tagged commit, on a clean runner.
+#
+# To ship a desktop version: publish a GitHub Release tagged desktop-v<version> (e.g.
+# desktop-v0.2.0). This job builds it, attaches the zip and its checksum, and prints the checksum
+# in the run summary so it can go in the release notes.
+#
+# Releases tagged v<version> are the NuGet packages and are handled by nuget.yml; the two
+# workflows ignore each other's tags on purpose.
+name: Release desktop app
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch: # dry run: builds and keeps the zip as a run artifact, uploads nothing
+
+permissions:
+  contents: write # required to attach assets to the release
+
+jobs:
+  build:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref_name, 'desktop-v')
+    runs-on: windows-latest # WPF and WebView2 — this cannot be built anywhere else
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Work out the version
+        id: version
+        shell: pwsh
+        run: |
+          # A dispatch run has no release tag, so it builds something deliberately unshippable.
+          if ($env:GITHUB_EVENT_NAME -eq 'release') {
+            $version = $env:GITHUB_REF_NAME -replace '^desktop-v', ''
+          } else {
+            $version = '0.0.0-dev'
+          }
+          $name = "SignsOfAI-Desktop-$version-win-x64"
+          "version=$version" >> $env:GITHUB_OUTPUT
+          "name=$name"       >> $env:GITHUB_OUTPUT
+          Write-Host "Building $name"
+
+      # A release that crashes is worse than a release that never shipped, and a GitHub Release
+      # cannot be un-downloaded once people have it.
+      - name: Test
+        run: dotnet test SignsOfAI.Desktop.slnx -c Release --nologo
+
+      # Self-contained: no .NET install on the user's machine. Not single-file — the WebView needs
+      # wwwroot on disk next to the executable, which is why the release notes tell people to keep
+      # the folder together. Publishing into a folder already named for the release means unzipping
+      # produces that name rather than a bare `publish`.
+      - name: Publish
+        shell: pwsh
+        run: |
+          dotnet publish src/SignsOfAI.Desktop `
+            -c Release -r win-x64 --self-contained `
+            -p:Version=${{ steps.version.outputs.version }} `
+            -o "staging/${{ steps.version.outputs.name }}" `
+            --nologo
+
+      - name: Zip and checksum
+        id: package
+        shell: pwsh
+        run: |
+          $name = "${{ steps.version.outputs.name }}"
+          Compress-Archive -Path "staging/$name" -DestinationPath "$name.zip" -CompressionLevel Optimal
+          $hash = (Get-FileHash "$name.zip" -Algorithm SHA256).Hash.ToLower()
+          # The sidecar travels with the release; the summary is for pasting into the notes, which
+          # have carried the checksum inline since desktop-v0.1.0.
+          "sha256  $hash" | Set-Content "$name.zip.sha256" -NoNewline
+          "sha256=$hash" >> $env:GITHUB_OUTPUT
+
+          $mb = [math]::Round((Get-Item "$name.zip").Length / 1MB)
+          @(
+            "### $name.zip"
+            ""
+            "- **$mb MB**"
+            "- ``sha256  $hash``"
+            ""
+            "Paste the checksum line into the release notes."
+          ) | Add-Content $env:GITHUB_STEP_SUMMARY
+
+      - name: Attach to the release
+        if: github.event_name == 'release'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $name = "${{ steps.version.outputs.name }}"
+          gh release upload $env:GITHUB_REF_NAME "$name.zip" "$name.zip.sha256" --clobber
+
+      # Dispatch runs produce something to download and check by hand before tagging for real.
+      - name: Keep the build as a run artifact
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.version.outputs.name }}
+          path: ${{ steps.version.outputs.name }}.zip
+          retention-days: 7

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -61,6 +61,17 @@ jobs:
             exit 1
           fi
 
+          # Symbols are a .NET Foundation eligibility criterion, and a silent gap here would only
+          # surface months later when someone tries to step into the library. Every .nupkg must
+          # have its .snupkg beside it — that adjacency is also what makes the push pick it up.
+          for pkg in out/*."$want".nupkg; do
+            if [ ! -f "${pkg%.nupkg}.snupkg" ]; then
+              echo "::error::$pkg has no matching .snupkg — symbol publishing is broken."
+              echo "Check IncludeSymbols/SymbolPackageFormat in Directory.Build.props."
+              exit 1
+            fi
+          done
+
           # The MCP manifest carries its own version twice, and the MCP registry serves it to
           # clients. If it drifts, the registry advertises a version that doesn't exist.
           manifest="src/SignsOfAI.Mcp/.mcp/server.json"
@@ -79,6 +90,9 @@ jobs:
         with:
           user: peopleworksservices
 
+      # The glob deliberately names only *.nupkg: the NuGet client pushes the matching .snupkg
+      # to the symbol server on its own whenever one sits next to the package. Adding *.snupkg
+      # here would push each symbol package twice.
       - name: Push to NuGet
         run: |
           dotnet nuget push "out/*.nupkg" \

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,36 @@
+<Project>
+
+  <!--
+    Repo-wide build settings, imported before every .csproj (so any project can still
+    override a value by re-declaring it).
+
+    These exist to satisfy the .NET Foundation eligibility criteria for Code:
+    reproducible builds, Source Link, and symbols. See Docs/dotnet-foundation.md.
+  -->
+
+  <PropertyGroup>
+    <!-- Reproducible builds. Deterministic is already the SDK default; it is stated here
+         because it is part of the contract, not an accident of the toolchain.
+         ContinuousIntegrationBuild normalizes absolute paths into the PDB, which is what
+         makes two CI builds of the same commit byte-identical. It is deliberately OFF for
+         local builds: normalized paths break step-through debugging in the IDE. -->
+    <Deterministic>true</Deterministic>
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+
+    <!-- Source Link. Since the .NET 8 SDK the GitHub provider ships in-box, so this needs
+         no PackageReference: setting PublishRepositoryUrl is what turns it on.
+         EmbedUntrackedSources covers generated files that are not in git (e.g. the
+         AssemblyInfo the SDK writes), which would otherwise be unresolvable in a debugger. -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/peopleworks/SignsofAI</RepositoryUrl>
+
+    <!-- Symbols, as a .snupkg pushed alongside each .nupkg to the NuGet symbol server.
+         Portable PDBs are the format Source Link annotates. -->
+    <DebugType>portable</DebugType>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+</Project>

--- a/Docs/dotnet-foundation.md
+++ b/Docs/dotnet-foundation.md
@@ -1,0 +1,69 @@
+# .NET Foundation eligibility — where this repository stands
+
+A working record of the project against the [.NET Foundation eligibility
+criteria](https://github.com/dotnet-foundation/projects#eligibility-criteria), kept in the repo so
+the claims are checkable rather than asserted. Each row says where the evidence lives.
+
+Last reviewed: 2026-08-01, at version 0.2.1.
+
+## Suitability
+
+| Criterion | Status | Evidence |
+|---|---|---|
+| Built on .NET and/or creates value in the .NET ecosystem | Met | `net10.0` throughout. Ships a library (`SignsOfAI.Core`), a `dotnet tool` (`SignsOfAI.Cli`), an MCP server (`SignsOfAI.Mcp`), a Blazor WebAssembly site and a WPF desktop app. |
+| Collaborative development philosophy | Met | `CONTRIBUTING.md`. The extension points that matter — the detection rules and the sign catalog — are JSON data files (`src/SignsOfAI.Core/Rules/Packs/rules.{en,es}.json`), not compiled C#, specifically so that a contributor with domain knowledge and no .NET can open a pull request. `Docs/TRANSLATING.md` covers adding a language. |
+
+## Code
+
+| Criterion | Status | Evidence |
+|---|---|---|
+| Source code distributed to the public at no charge | Met | MIT, no paid tier, no gated features. |
+| Discoverable and publicly accessible | Met | <https://github.com/peopleworks/SignsofAI> |
+| Build script produces artifacts identical to the official ones | Partly met | The NuGet packages are built and published only by `.github/workflows/nuget.yml` — there is no local publish path. The desktop `.zip` attached to `desktop-v0.1.0` was produced locally; see *Known gaps*. |
+| Reproducible build settings | Met | `Directory.Build.props`: `Deterministic`, plus `ContinuousIntegrationBuild` under `GITHUB_ACTIONS` so CI builds normalize paths and local builds stay debuggable. |
+| Source Link | Met | `Directory.Build.props`: `PublishRepositoryUrl` + `EmbedUntrackedSources`. The GitHub provider is in-box since the .NET 8 SDK, so no `PackageReference` is needed. Verified: the packed `.nuspec` carries `<repository … commit="…">` and the PDB carries the `raw.githubusercontent.com/.../<commit>/*` map. |
+| Embedded PDBs or symbol packages | Met | `.snupkg` per package (`IncludeSymbols`, `SymbolPackageFormat=snupkg`), pushed to the NuGet symbol server alongside each `.nupkg`. `nuget.yml` fails the release if any package is missing its symbols. |
+| Artifacts are code signed | **Not met** | See *Known gaps*. |
+
+## Licenses and copyright
+
+| Criterion | Status | Evidence |
+|---|---|---|
+| At least one permissive OSI-approved license | Met | MIT (`LICENSE`, and `PackageLicenseExpression` in every packed project). |
+| Mandatory dependencies are permissively licensed | Met | `SignsOfAI.Core` has **no** package dependencies at all. Across the repository: `ModelContextProtocol` (Apache-2.0), `PdfPig` (Apache-2.0), `Tokenizers.DotNet` (MIT), `Microsoft.ML.OnnxRuntime` (MIT), `Microsoft.Extensions.*` and `Microsoft.AspNetCore.*` (MIT). |
+| Committers bound by a CLA | Willing | No CLA today — every commit to date is by the project lead. The project will adopt the .NET Foundation CLA and its bot on onboarding. |
+| Copyright ownership clearly defined | Met | `LICENSE`: Copyright (c) 2026 Pedro Hernández — PeopleWorks. `Authors`/`Company` set on every packed project. |
+
+## Community
+
+| Criterion | Status | Evidence |
+|---|---|---|
+| Public homepage with status and purpose | Met | <https://peopleworks.github.io/SignsofAI/> — the live application is the homepage. |
+| Public issue tracker | Met | GitHub Issues, with templates under `.github/ISSUE_TEMPLATE`. |
+| Published security policy | Met | `SECURITY.md` |
+| Public communication channel with maintainers | Partly met | GitHub Issues is open and answered. GitHub Discussions is **not** enabled yet — see *Known gaps*. |
+| Publicly reviewable and contributable documentation | Met | `README.md`, `Docs/`, and the in-product explanations — every finding the analyzer reports links to the catalog entry that justifies it. |
+| Code of Conduct | Met | `CODE_OF_CONDUCT.md` (Contributor Covenant); to be relinked to the .NET Foundation Code of Conduct on onboarding. |
+| Account/organization 2FA | Unverified | `peopleworks` is a user account, not an organization, so there is no org-level setting to point at. To be confirmed by the account owner before the application is filed. |
+
+## Known gaps
+
+**Code signing.** Nothing this project ships is signed. The NuGet packages are unsigned, and the
+self-contained desktop `.zip` on `desktop-v0.1.0` triggers a SmartScreen warning on first run —
+documented in the release notes rather than hidden, but still the roughest edge a new user hits.
+An Authenticode certificate is the fix, and it is the single concrete resource the project would
+ask the Foundation for.
+
+**The desktop release is not built by CI.** `ci.yml` builds and tests the desktop app on a
+`windows-latest` runner, but the published `.zip` was produced on a developer machine. Until a
+`desktop-release.yml` publishes it from a tag, the "identical artifacts" criterion holds for the
+NuGet packages and not for the desktop download.
+
+**No discussion forum.** Issues are the only channel today. GitHub Discussions is one repository
+setting away and costs nothing, and it is the difference between "you may report a defect" and
+"you may talk to the maintainer" — which is what this criterion is actually asking for.
+
+**One contributor.** 88 commits, all by the project lead, first commit 2026-07-05. The project can
+show that it is *built* for contribution — JSON rule packs, a translation guide, issue and PR
+templates — but it cannot yet show contributors it has promoted, so the reasonable outcome of an
+application is Seed rather than Member.

--- a/Docs/dotnet-foundation.md
+++ b/Docs/dotnet-foundation.md
@@ -19,7 +19,7 @@ Last reviewed: 2026-08-01, at version 0.2.1.
 |---|---|---|
 | Source code distributed to the public at no charge | Met | MIT, no paid tier, no gated features. |
 | Discoverable and publicly accessible | Met | <https://github.com/peopleworks/SignsofAI> |
-| Build script produces artifacts identical to the official ones | Partly met | The NuGet packages are built and published only by `.github/workflows/nuget.yml` — there is no local publish path. The desktop `.zip` attached to `desktop-v0.1.0` was produced locally; see *Known gaps*. |
+| Build script produces artifacts identical to the official ones | Met | Everything the project ships is built by a workflow from the tagged commit on a clean runner, never from a developer machine: `.github/workflows/nuget.yml` for the packages, `desktop-release.yml` for the Windows desktop `.zip`, `deploy-pages.yml` for the site. The desktop release also publishes a SHA-256 sidecar. |
 | Reproducible build settings | Met | `Directory.Build.props`: `Deterministic`, plus `ContinuousIntegrationBuild` under `GITHUB_ACTIONS` so CI builds normalize paths and local builds stay debuggable. |
 | Source Link | Met | `Directory.Build.props`: `PublishRepositoryUrl` + `EmbedUntrackedSources`. The GitHub provider is in-box since the .NET 8 SDK, so no `PackageReference` is needed. Verified: the packed `.nuspec` carries `<repository … commit="…">` and the PDB carries the `raw.githubusercontent.com/.../<commit>/*` map. |
 | Embedded PDBs or symbol packages | Met | `.snupkg` per package (`IncludeSymbols`, `SymbolPackageFormat=snupkg`), pushed to the NuGet symbol server alongside each `.nupkg`. `nuget.yml` fails the release if any package is missing its symbols. |
@@ -41,10 +41,10 @@ Last reviewed: 2026-08-01, at version 0.2.1.
 | Public homepage with status and purpose | Met | <https://peopleworks.github.io/SignsofAI/> — the live application is the homepage. |
 | Public issue tracker | Met | GitHub Issues, with templates under `.github/ISSUE_TEMPLATE`. |
 | Published security policy | Met | `SECURITY.md` |
-| Public communication channel with maintainers | Partly met | GitHub Issues is open and answered. GitHub Discussions is **not** enabled yet — see *Known gaps*. |
+| Public communication channel with maintainers | Met | GitHub Issues, and GitHub Discussions — including a *False positives* category, which is where a rule that misfires gets reported. The tool has no server and no telemetry, so a reported false positive is the only signal the project ever receives that a rule is wrong. |
 | Publicly reviewable and contributable documentation | Met | `README.md`, `Docs/`, and the in-product explanations — every finding the analyzer reports links to the catalog entry that justifies it. |
 | Code of Conduct | Met | `CODE_OF_CONDUCT.md` (Contributor Covenant); to be relinked to the .NET Foundation Code of Conduct on onboarding. |
-| Account/organization 2FA | Unverified | `peopleworks` is a user account, not an organization, so there is no org-level setting to point at. To be confirmed by the account owner before the application is filed. |
+| Account/organization 2FA | Met | Enabled on the PeopleWorks GitHub account, confirmed by the account owner. |
 
 ## Known gaps
 
@@ -53,15 +53,6 @@ self-contained desktop `.zip` on `desktop-v0.1.0` triggers a SmartScreen warning
 documented in the release notes rather than hidden, but still the roughest edge a new user hits.
 An Authenticode certificate is the fix, and it is the single concrete resource the project would
 ask the Foundation for.
-
-**The desktop release is not built by CI.** `ci.yml` builds and tests the desktop app on a
-`windows-latest` runner, but the published `.zip` was produced on a developer machine. Until a
-`desktop-release.yml` publishes it from a tag, the "identical artifacts" criterion holds for the
-NuGet packages and not for the desktop download.
-
-**No discussion forum.** Issues are the only channel today. GitHub Discussions is one repository
-setting away and costs nothing, and it is the difference between "you may report a defect" and
-"you may talk to the maintainer" — which is what this criterion is actually asking for.
 
 **One contributor.** 88 commits, all by the project lead, first commit 2026-07-05. The project can
 show that it is *built* for contribution — JSON rule packs, a translation guide, issue and PR

--- a/src/SignsOfAI.Cli/SignsOfAI.Cli.csproj
+++ b/src/SignsOfAI.Cli/SignsOfAI.Cli.csproj
@@ -13,7 +13,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>signsofai</ToolCommandName>
     <PackageId>SignsOfAI.Cli</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
     <Authors>Pedro Hernández (PeopleWorks)</Authors>
     <Company>PeopleWorks</Company>
     <Description>CLI to detect the signs of AI writing (English &amp; Spanish) and recommend fixes — lint your prose in CI.</Description>

--- a/src/SignsOfAI.Core/SignsOfAI.Core.csproj
+++ b/src/SignsOfAI.Core/SignsOfAI.Core.csproj
@@ -10,7 +10,7 @@
 
     <!-- Publishable as a library so others can embed the engine. -->
     <PackageId>SignsOfAI.Core</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
     <Authors>Pedro Hernández (PeopleWorks)</Authors>
     <Company>PeopleWorks</Company>
     <Description>The engine behind Signs of AI Writing: detects the stylometric tells of AI-generated text (English &amp; Spanish) — overused vocabulary, rhetorical crutches, syntactic tells and burstiness — and returns an actionable fix for each finding. No external dependencies.</Description>

--- a/src/SignsOfAI.Mcp/.mcp/server.json
+++ b/src/SignsOfAI.Mcp/.mcp/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.peopleworks/signs-of-ai",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "title": "Signs of AI Writing",
   "description": "Bilingual (EN/ES) AI-writing detection that shows the evidence, plus originality checking.",
   "packages": [
@@ -9,7 +9,7 @@
       "registryType": "nuget",
       "registryBaseUrl": "https://api.nuget.org/v3/index.json",
       "identifier": "SignsOfAI.Mcp",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/SignsOfAI.Mcp/SignsOfAI.Mcp.csproj
+++ b/src/SignsOfAI.Mcp/SignsOfAI.Mcp.csproj
@@ -12,7 +12,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>signsofai-mcp</ToolCommandName>
     <PackageId>SignsOfAI.Mcp</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
     <Authors>Pedro Hernández (PeopleWorks)</Authors>
     <Company>PeopleWorks</Company>
     <Description>Model Context Protocol (MCP) server for Signs of AI Writing. Exposes the engine as tools — analyze text for AI tells, check originality between documents, search the sign catalog, extract distinctive phrases, and (optionally, via the hosted API) measure perplexity and find paraphrases — to Claude Desktop and any MCP client.</Description>


### PR DESCRIPTION
Preparation for a [.NET Foundation project application](https://github.com/dotnet-foundation/projects#eligibility-criteria). Four of the eligibility criteria were unmet. Three of them were not decisions — there was no `Directory.Build.props`, so nothing set them.

## What changed

**`Directory.Build.props`** — new, repo-wide.

- **Source Link.** No `PackageReference` needed since the .NET 8 SDK; `PublishRepositoryUrl` is the switch.
- **Reproducible builds.** `ContinuousIntegrationBuild` is scoped to `GITHUB_ACTIONS` deliberately: it normalizes absolute paths into the PDB, which is what makes two CI builds of a commit byte-identical, and is also what breaks step-through debugging locally.
- **Symbols.** A `.snupkg` per package, pushed to the NuGet symbol server alongside the `.nupkg`.

**`nuget.yml`** now fails a release if any `.nupkg` lacks its `.snupkg`. Missing symbols are invisible until somebody tries to step into the library months later.

**`desktop-release.yml`** — new. The zip on `desktop-v0.1.0` was built on a developer machine, which is the one thing the "identical deployable artifacts" criterion does not tolerate. It is now built on a clean `windows-latest` runner from the tagged commit, tests first, with a published SHA-256.

**Versions to 0.2.1** across the three packages and the MCP manifest, so the Source Link and symbol claims become true of a *published* version rather than only of `main`.

**`Docs/dotnet-foundation.md`** — a per-criterion record with the evidence for each row, including what is still unmet.

## Verified, not assumed

- Packed 0.2.1: the `.nuspec` carries `<repository … commit="…">`, and the PDB carries the `raw.githubusercontent.com/.../<commit>/*` map.
- All three packages produce `.nupkg` + `.snupkg`. The new CI guard was simulated against them and passes.
- The desktop publish command succeeds locally and `-p:Version` reaches the exe's `ProductVersion`.
- 211 tests pass. All workflow YAML parses.

## What this does not fix

**Code signing.** Nothing the project ships is signed, and the desktop zip still trips SmartScreen. An Authenticode certificate is the single concrete thing the project would ask the Foundation for — so this stays open on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
