### PR TITLE
Write the part a teacher needs first, which is not software

### DIFF
--- a/Docs/Teaching/README.md
+++ b/Docs/Teaching/README.md
@@ -1,0 +1,104 @@
+# For teachers — the part that is not software
+
+*[Español abajo.](#para-docentes--la-parte-que-no-es-software)*
+
+Six pieces of software have been built for this project. None of them is what a teacher needs first.
+
+What a teacher needs first is language for a syllabus, a page to hand students before anything goes
+wrong, and a procedure for the day a question becomes formal. None of that requires this tool, or
+any tool. It is here because the hardest part of AI writing in a classroom was never detection — it
+is what you do on the morning you suspect something, and there is nobody to ask.
+
+**Use these however you like. Copy them, edit them, put your institution's name on them, translate
+them. No licence, no attribution, no permission.** If they end up useful, we would like to hear how
+you changed them — an issue or a pull request improves them for the next person.
+
+| | | |
+|---|---|---|
+| **[Syllabus language](syllabus.en.md)** | [ES](syllabus.es.md) | Three policies at different strengths, ready to paste. Pick one — mixing them is how these fail. |
+| **[The student sheet](student-sheet.en.md)** | [ES](student-sheet.es.md) | One page, written for students: what a flag means, what it does not, and what protects them. |
+| **[Committee procedure](committee.en.md)** | [ES](committee.es.md) | For when it becomes formal, assuming the hardest case — the student denies it. |
+
+## The three things these documents agree on
+
+**A score is never the reason for a decision about a student.** Not at any threshold, not with any
+tool, not ours. A detector tells you where to read; it does not tell you what happened. Every
+document here is built so that a decision made by following it would survive the tool being removed
+from it entirely.
+
+**A conversation about the work settles what no software can.** Someone who wrote a text can say why
+it is that text — why this example, what was left out, what a phrase of theirs means. Someone who did
+not can restate it and cannot say why. That asymmetry is free, it takes ten minutes, and it is
+stronger than anything in this repository.
+
+**The burden does not go on the student.** Asking somebody to prove they wrote something reverses it
+onto the person with the least power in the room, and it lands hardest on students writing in a
+second language — the group every published study finds these tools flag most often. Ask them to talk
+about their work instead.
+
+## Why this project is entitled to say any of it
+
+Because it publishes how often it is wrong, which almost nothing in this category does:
+[`Docs/CALIBRATION.md`](../CALIBRATION.md). Ninety texts published before generative models existed,
+zero flagged at the recommended threshold, and the honest reading is the interval rather than the
+zero — under 4.1%.
+
+Read further down that page and it says something less flattering, which is the part that matters
+here: **no threshold is supported for English or Spanish on its own.** The corpus is too thin per
+language. A figure measured mostly in one language, quoted at a student writing in another, is the
+exact error these documents tell a committee not to make.
+
+Everything runs offline. No document, or any part of one, leaves the machine it is on.
+
+---
+
+# Para docentes — la parte que no es software
+
+Este proyecto ha construido seis piezas de software. Ninguna es lo que un docente necesita primero.
+
+Lo que un docente necesita primero es un texto para el programa de la asignatura, una página que
+entregar a los estudiantes antes de que pase nada, y un procedimiento para el día en que una duda se
+vuelve formal. Nada de eso requiere esta herramienta ni ninguna otra. Está aquí porque lo difícil de
+la escritura con IA en un aula nunca fue detectarla: es qué hacer la mañana en que uno sospecha algo
+y no tiene a quién preguntar.
+
+**Úselos como quiera. Cópielos, edítelos, póngales el nombre de su institución, tradúzcalos. Sin
+licencia, sin atribución, sin permiso.** Si le resultan útiles, nos gustaría saber cómo los cambió —
+una incidencia o un *pull request* los mejora para la próxima persona.
+
+| | |
+|---|---|
+| **[Texto para el programa](syllabus.es.md)** | Tres políticas de distinta intensidad, listas para pegar. Elija una: mezclarlas es como fracasan. |
+| **[La hoja del estudiante](student-sheet.es.md)** | Una página escrita para el estudiante: qué significa que lo marquen, qué no, y qué lo protege. |
+| **[Procedimiento del comité](committee.es.md)** | Para cuando se vuelve formal, asumiendo el caso más difícil: el estudiante lo niega. |
+
+## Las tres cosas en que estos documentos coinciden
+
+**Una puntuación nunca es el motivo de una decisión sobre un estudiante.** Con ningún umbral, con
+ninguna herramienta, tampoco la nuestra. Un detector le dice dónde leer; no le dice qué pasó. Todos
+estos documentos están construidos para que una decisión tomada siguiéndolos sobreviva a eliminar la
+herramienta por completo.
+
+**Una conversación sobre el trabajo resuelve lo que ningún programa puede.** Quien escribió un texto
+puede decir por qué es ese texto: por qué ese ejemplo, qué dejó fuera, qué significa una expresión
+suya. Quien no lo escribió puede reformularlo y no puede decir por qué. Esa asimetría es gratis,
+lleva diez minutos, y es más fuerte que cualquier cosa de este repositorio.
+
+**La carga no recae sobre el estudiante.** Pedirle a alguien que demuestre que escribió algo invierte
+la carga sobre la persona con menos poder de la sala, y cae con más fuerza sobre quien escribe en una
+segunda lengua — el grupo que todos los estudios publicados encuentran marcado con más frecuencia por
+estas herramientas. Pídale que hable de su trabajo.
+
+## Por qué este proyecto puede permitirse decir todo esto
+
+Porque publica con qué frecuencia se equivoca, cosa que casi nadie hace en esta categoría:
+[`Docs/CALIBRATION.md`](../CALIBRATION.md). Noventa textos publicados antes de que existieran los
+modelos generativos, ninguno marcado en el umbral recomendado, y la lectura honesta es el intervalo y
+no el cero: por debajo del 4,1%.
+
+Siga leyendo esa página y dice algo menos halagador, que es justo lo que importa aquí: **ni el
+español ni el inglés respaldan por sí solos un umbral propio.** El corpus es demasiado delgado por
+idioma. Una cifra medida mayoritariamente en un idioma, citada frente a un estudiante que escribe en
+otro, es exactamente el error que estos documentos le piden a un comité que no cometa.
+
+Todo funciona sin conexión. Ningún documento, ni fragmento de él, sale del equipo donde está.

--- a/Docs/Teaching/committee.en.md
+++ b/Docs/Teaching/committee.en.md
@@ -1,0 +1,129 @@
+# A procedure for when the question becomes formal
+
+For an academic-integrity committee, a programme director, or a teacher who has to write something
+down. It assumes the hardest case: the student denies it.
+
+**The one rule the rest depends on:** a detector's output is never evidence of authorship, and no
+part of this procedure treats it as such. What follows is how to reach a defensible decision anyway.
+
+---
+
+## Sort what you have into three kinds
+
+Most flawed integrity cases collapse because these were mixed together in one paragraph.
+
+**1. Checkable facts.** Statements about the document that are true or false and that anyone can
+verify independently — this citation appears in the text and nowhere in the reference list; these two
+references carry the same DOI, so at most one of them is right; this reference is dated next year;
+this word contains a Cyrillic letter shaped like a Latin one.
+
+These do not depend on trusting any tool. **Anyone can check them by hand**, and a committee should:
+open the bibliography, look. They also carry no opinion about authorship — a real source can be
+produced in seconds, and that request is the whole test.
+
+**2. A pattern score.** An opinion about prose. Useful for deciding where to read carefully. **It is
+not evidence and it belongs in no finding.** If your written decision would be weaker with this
+paragraph removed, the decision is not sound.
+
+**3. What the student says about their own work.** In practice this decides the case, and the rest of
+this document is about getting it right.
+
+## Before the meeting
+
+**Verify the checkable facts yourself.** Look up the DOIs. Search the reference list. If a claimed
+contradiction does not hold when you check it by hand, drop it — one wrong item in a written finding
+is enough to void the whole document at appeal, and rightly.
+
+**Write down what specifically raised the question**, in one or two sentences a student could
+understand. If you cannot, there is no case yet. *"The score was high"* is not a reason. *"Four of
+the six sources cited do not appear in the bibliography, and two share a DOI"* is.
+
+**Check the tool's error rate for the language the work is written in.** This matters more than it
+sounds. This tool's corpus supports **no threshold for Spanish or English separately** — its best
+bounds are 5.6% and 13.3% by language, against an aggregate of 4.1%. Quoting an aggregate measured
+mostly on one language, at a student writing in another, is the exact error the tool's own
+documentation warns against. If you cite a figure in a finding, cite the one for that language, and
+if there is none, say there is none.
+
+**Decide who is in the room.** For the student: someone they choose. The power difference is the
+main source of unfair outcomes in these meetings, and it is cheap to reduce.
+
+## The meeting
+
+**Open by saying what it is.** *"This is a conversation about your assignment, not a decision. Nothing
+has been decided."* Say it even if you think it is obvious. It is not obvious from the other chair.
+
+**Ask about the work, not about the accusation.** Take two or three specific passages and ask:
+
+> *You wrote this phrase here — what does it mean, in your own words?*
+>
+> *Why this example and not another one?*
+>
+> *What did you leave out of this section, and why?*
+>
+> *Where did this source come from? What does it actually argue?*
+
+Someone who wrote a text can talk about the choices in it — not perfectly, not fluently, but they can
+say why. Someone who did not write it produces summary rather than intention: they can restate the
+paragraph and cannot say why it is that paragraph. **This asymmetry is the strongest instrument in the
+room, and it is free.**
+
+**Ask for the sources.** Not the citations, the sources. A real one arrives in seconds. An invented
+one cannot arrive at all, and the failure to produce it is a fact you may write down.
+
+**Ask for the drafts, but weigh their absence carefully.** Drafts are strong evidence when present
+and weak evidence when missing. Plenty of honest students write in one pass, in one file, and delete
+nothing because there was nothing to delete. Absence of drafts is not evidence of anything, and a
+policy that treats it as such punishes people for how they work.
+
+**Take the answers seriously when they explain things.** *"I write formally because that is how I was
+taught"* is a complete explanation for a high score, and it is a common one among students writing in
+a second language. A committee that has decided in advance what the meeting will conclude is not
+holding a meeting.
+
+## Writing the decision
+
+The document should be able to stand with the detector removed from it entirely. Test that literally:
+delete every sentence about the tool and read what is left. If a decision remains, write it. If
+nothing remains, there is no finding.
+
+**State the facts you verified yourself** and how you verified them. **State what the student said.**
+**State what you concluded and why.** If you mention the tool at all, say what it is and what it is
+not, in the finding itself:
+
+> A writing-analysis tool was used to decide which sections to examine. Its output is not evidence of
+> authorship and was not treated as such. It publishes a false-positive rate on writing known to be
+> human of under 4.1% overall, with no threshold supported for either language on its own — the
+> findings below rest on the source verification and the interview, not on that tool.
+
+A committee that writes this sentence is in a stronger position than one that omits it, because the
+sentence is going to be raised at appeal whether or not it appears.
+
+## Proportion
+
+Most of what these processes catch is not fabrication. It is a student who was overwhelmed, used a
+tool for a paragraph, and did not disclose it because nobody told them how. A first response of
+*rewrite it and tell me what you used* keeps a student in the room and produces a better writer. The
+severe outcomes should be reserved for what deserves them: invented sources, work bought or taken
+from another person, and denial maintained against facts the student cannot explain.
+
+---
+
+## What this project will not give you
+
+**A confidence percentage.** It does not have one, and neither does anyone else who prints one.
+
+**A verdict below its supported threshold.** The report prints the number and no interpretation.
+That is deliberate: a page that says *reads mostly human* above *treat this score as saying nothing*
+lets the reader keep whichever half they came in wanting.
+
+**A false-positive rate for your student population.** The published figure was measured on articles
+published before generative models existed — not on first-year coursework, not on your institution,
+not on your language mix. It is a floor, not a promise. Anyone quoting it as though it applied
+directly to a nineteen-year-old's essay is overstating it, including us.
+
+---
+
+Related: [`syllabus.en.md`](syllabus.en.md) — policy language before any of this is needed.
+[`student-sheet.en.md`](student-sheet.en.md) — what students should know beforehand.
+[`../CALIBRATION.md`](../CALIBRATION.md) — the error rate and its method.

--- a/Docs/Teaching/committee.es.md
+++ b/Docs/Teaching/committee.es.md
@@ -1,0 +1,135 @@
+# Procedimiento para cuando la duda se vuelve formal
+
+Para un comité de integridad académica, una dirección de carrera, o un profesor que tiene que dejar
+algo por escrito. Asume el caso más difícil: el estudiante lo niega.
+
+**La regla de la que depende todo lo demás:** el resultado de un detector nunca es prueba de autoría,
+y ninguna parte de este procedimiento lo trata como tal. Lo que sigue es cómo llegar aun así a una
+decisión defendible.
+
+---
+
+## Separe lo que tiene en tres clases
+
+La mayoría de los expedientes defectuosos se caen porque estas tres cosas iban mezcladas en un mismo
+párrafo.
+
+**1. Hechos comprobables.** Afirmaciones sobre el documento que son verdaderas o falsas y que
+cualquiera puede verificar por su cuenta: esta cita aparece en el texto y en ninguna parte de la
+bibliografía; estas dos referencias llevan el mismo DOI, así que como mucho una de las dos es
+correcta; esta referencia está fechada el año que viene; esta palabra contiene una letra cirílica con
+forma de latina.
+
+No dependen de confiar en ninguna herramienta. **Cualquiera puede comprobarlos a mano**, y un comité
+debería hacerlo: abra la bibliografía y mire. Además no opinan sobre la autoría — una fuente real se
+produce en segundos, y pedirla es toda la prueba.
+
+**2. Una puntuación de patrones.** Una opinión sobre la prosa. Sirve para decidir dónde leer con
+atención. **No es prueba y no pertenece a ningún expediente.** Si su resolución escrita quedara más
+débil al eliminar ese párrafo, la resolución no es sólida.
+
+**3. Lo que el estudiante dice sobre su propio trabajo.** En la práctica esto decide el caso, y el
+resto de este documento trata de hacerlo bien.
+
+## Antes de la reunión
+
+**Verifique usted mismo los hechos comprobables.** Busque los DOI. Busque en la bibliografía. Si una
+contradicción no se sostiene al comprobarla a mano, elimínela: un solo dato erróneo en un expediente
+basta para anularlo entero en apelación, y con razón.
+
+**Escriba qué generó la duda exactamente**, en una o dos frases que un estudiante pueda entender. Si
+no puede, todavía no hay caso. *«La puntuación era alta»* no es un motivo. *«Cuatro de las seis
+fuentes citadas no aparecen en la bibliografía, y dos comparten el mismo DOI»* sí lo es.
+
+**Consulte la tasa de error para el idioma en que está escrito el trabajo.** Esto importa más de lo
+que parece. El corpus de esta herramienta **no respalda ningún umbral para el español ni para el
+inglés por separado**: sus mejores cotas por idioma son 5,6% y 13,3%, frente a un agregado de 4,1%.
+Citar un agregado medido mayoritariamente en un idioma, frente a un estudiante que escribe en otro,
+es exactamente el error contra el que advierte la propia documentación de la herramienta. Si cita una
+cifra en una resolución, cite la de ese idioma; y si no existe, diga que no existe.
+
+**Decida quién está en la sala.** Por parte del estudiante, alguien elegido por él. La diferencia de
+poder es la principal fuente de resultados injustos en estas reuniones, y reducirla es barato.
+
+## La reunión
+
+**Empiece diciendo qué es esto.** *«Esta es una conversación sobre su trabajo, no una decisión. No se
+ha decidido nada.»* Dígalo aunque le parezca obvio. Desde la otra silla no lo es.
+
+**Pregunte por el trabajo, no por la acusación.** Tome dos o tres pasajes concretos y pregunte:
+
+> *Escribió esta expresión aquí: ¿qué significa, con sus palabras?*
+>
+> *¿Por qué este ejemplo y no otro?*
+>
+> *¿Qué dejó fuera de esta sección, y por qué?*
+>
+> *¿De dónde salió esta fuente? ¿Qué sostiene realmente?*
+
+Quien escribió un texto puede hablar de las decisiones que hay en él — no con perfección ni con
+fluidez, pero puede decir por qué. Quien no lo escribió produce resumen en lugar de intención: puede
+reformular el párrafo y no puede decir por qué es ese párrafo. **Esa asimetría es el instrumento más
+potente de la sala, y es gratis.**
+
+**Pida las fuentes.** No las citas: las fuentes. Una real llega en segundos. Una inventada no puede
+llegar, y esa imposibilidad sí es un hecho que puede consignar.
+
+**Pida los borradores, pero pese su ausencia con cuidado.** Los borradores son prueba fuerte cuando
+están y prueba débil cuando faltan. Hay estudiantes honestos que escriben de una sola pasada, en un
+solo archivo, y no borran nada porque no había nada que borrar. La ausencia de borradores no prueba
+nada, y una política que la trate como prueba castiga a la gente por su forma de trabajar.
+
+**Tome en serio las respuestas cuando explican algo.** *«Escribo formalmente porque así me
+enseñaron»* es una explicación completa para una puntuación alta, y es frecuente entre quienes
+escriben en una segunda lengua. Un comité que ya decidió de antemano qué va a concluir la reunión no
+está celebrando una reunión.
+
+## Al redactar la resolución
+
+El documento tiene que sostenerse con el detector eliminado por completo. Haga esa prueba
+literalmente: borre todas las frases sobre la herramienta y lea lo que queda. Si queda una
+resolución, escríbala. Si no queda nada, no hay caso.
+
+**Consigne los hechos que verificó usted** y cómo los verificó. **Consigne lo que dijo el
+estudiante.** **Consigne qué concluyó y por qué.** Si menciona la herramienta, diga en la propia
+resolución qué es y qué no es:
+
+> Se utilizó una herramienta de análisis de escritura para decidir qué secciones examinar. Su
+> resultado no es prueba de autoría y no se ha tratado como tal. Publica una tasa de falsos positivos
+> sobre escritura conocidamente humana inferior al 4,1% en agregado, sin que ningún idioma por
+> separado respalde un umbral propio; las conclusiones siguientes se apoyan en la verificación de
+> fuentes y en la entrevista, no en esa herramienta.
+
+Un comité que escribe esa frase queda en mejor posición que uno que la omite, porque la cuestión se
+va a plantear en apelación aparezca o no.
+
+## Proporción
+
+La mayoría de lo que estos procesos detectan no es fabricación. Es un estudiante desbordado que usó
+una herramienta para un párrafo y no lo declaró porque nadie le explicó cómo. Una primera respuesta
+del tipo *reescríbalo y dígame qué usó* mantiene al estudiante dentro y produce un mejor escritor.
+Las sanciones graves deben reservarse para lo que las merece: fuentes inventadas, trabajos comprados
+o tomados de otra persona, y la negación sostenida frente a hechos que el estudiante no puede
+explicar.
+
+---
+
+## Lo que este proyecto no le va a dar
+
+**Un porcentaje de confianza.** No lo tiene, y tampoco lo tiene nadie que lo imprima.
+
+**Un veredicto por debajo de su umbral respaldado.** El informe imprime el número y ninguna
+interpretación. Es deliberado: una página que dice *parece mayormente humano* encima de *trate esta
+puntuación como si no dijera nada* deja que el lector se quede con la mitad que ya traía decidida.
+
+**Una tasa de falsos positivos para su población estudiantil.** La cifra publicada se midió sobre
+artículos publicados antes de que existieran los modelos generativos — no sobre trabajos de primer
+año, ni sobre su institución, ni sobre su mezcla de idiomas. Es un suelo, no una promesa. Quien la
+cite como si se aplicara directamente al ensayo de un chico de diecinueve años la está exagerando,
+nosotros incluidos.
+
+---
+
+Relacionado: [`syllabus.es.md`](syllabus.es.md) — el texto de la norma, antes de necesitar nada de
+esto. [`student-sheet.es.md`](student-sheet.es.md) — lo que el estudiante debería saber de antemano.
+[`../CALIBRATION.md`](../CALIBRATION.md) — la tasa de error y su método.

--- a/Docs/Teaching/student-sheet.en.md
+++ b/Docs/Teaching/student-sheet.en.md
@@ -1,0 +1,93 @@
+# What happens if your work gets flagged
+
+**One page, for students. Hand it out at the start of term, not when something has already gone
+wrong.** Print it, paste it into the course page, translate it, change it. No permission needed.
+
+---
+
+## A tool cannot tell who wrote something
+
+There is no software that can look at a text and know whether a person or a machine produced it.
+Anyone who tells you otherwise is selling something.
+
+What these tools measure is whether writing *looks like* the patterns machines produce — even sentence
+lengths, certain stock phrases, a particular kind of hedging. Human beings write that way too. People
+who learned English or Spanish as a second language write that way more often, because they were
+taught the formal register and they stay inside it. People who were drilled in five-paragraph
+structure write that way. People who are careful write that way.
+
+**So being flagged is not evidence that you did anything.** It means a piece of software noticed
+patterns. Software notices patterns in innocent work constantly.
+
+## What this particular tool does and does not do
+
+It publishes how often it is wrong about writing known to be human — a figure almost no tool in this
+category will state about itself. On its test corpus of ninety texts published before AI writing
+existed, it flagged **none of them** at its recommended setting. But that is ninety texts, and the
+honest reading is the range around it, not the zero: somewhere **under about 4 in 100**.
+
+It also does something most tools refuse to do: **below its supported threshold it prints no verdict
+at all.** A low score is not a certificate that a person wrote something, and it does not claim to be
+one. A tool that detected nothing would also return a low score.
+
+Your work is not uploaded anywhere. It is analysed on your instructor's machine and it does not
+leave it.
+
+## What actually settles a question
+
+Not a number. **A conversation about your work.**
+
+If your instructor asks you about an assignment, they will probably ask things like:
+
+- *You wrote this phrase — what does it mean, in your own words?*
+- *Why did you choose this example rather than another one?*
+- *What did you leave out, and why?*
+- *Where did this source come from, and what does it actually say?*
+
+These are not trick questions and there is no correct-sounding answer to memorise. Someone who wrote
+a text can talk about the choices in it. Someone who did not, cannot. **That asymmetry, not any
+score, is what resolves these situations** — which is why the conversation is the point and the
+software is not.
+
+## Three things that protect you, and cost you almost nothing
+
+**Keep your drafts.** Whatever you write in — a document with version history, a folder of dated
+files, anything. A trail of a piece of work getting made is the most complete answer to any question
+about it, and it takes no effort to keep if you simply do not delete things.
+
+**Keep your sources.** Not just the citation — the actual PDF, the link, the page you read. One of
+the few things a machine genuinely cannot fake is a real source that says what you claim it says.
+
+**Ask before, not after.** If you are unsure whether a tool is allowed, ask. Every policy has an edge,
+and asking about the edge has never harmed a student. Using something and hoping is what harms them.
+
+## If you are asked about your work
+
+**Being asked is not an accusation.** Instructors ask about work for many reasons.
+
+Answer honestly, including about any AI tool you used and what you used it for. Under most policies
+disclosed use is allowed, or at worst carries far less weight than undisclosed use. Bring your drafts,
+your notes and your sources; if you have them, this usually ends in the same meeting.
+
+If you feel the conversation is going badly, ask two questions, calmly:
+
+> *What specifically in my work raised the question?*
+>
+> *What would I need to show to answer it?*
+
+Both are reasonable, and a fair process can answer both. If the only answer you receive is *the
+software said so*, that is not sufficient grounds for a decision about you — and your institution
+almost certainly has an appeals process that says the same. Ask for it in writing.
+
+## And if you did use AI
+
+Say so, as early as you can, and be specific. It will nearly always go better than being found out —
+and it goes better than a denial that later collapses, which is what turns a small penalty into a
+serious one.
+
+---
+
+This sheet describes [SignsOfAI](https://github.com/peopleworks/SignsofAI), an open-source tool that
+runs entirely offline. Its full error rate and the method behind it are published at
+[`Docs/CALIBRATION.md`](../CALIBRATION.md). You are allowed to read them; they are not secret, and
+they are not written for insiders.

--- a/Docs/Teaching/student-sheet.es.md
+++ b/Docs/Teaching/student-sheet.es.md
@@ -1,0 +1,95 @@
+# Qué pasa si marcan tu trabajo
+
+**Una página, para estudiantes. Entrégala al principio del cuatrimestre, no cuando algo ya salió
+mal.** Imprímela, pégala en el aula virtual, tradúcela, cámbiala. No hace falta permiso.
+
+---
+
+## Un programa no puede saber quién escribió algo
+
+No existe software capaz de mirar un texto y saber si lo produjo una persona o una máquina. Quien
+diga lo contrario está vendiendo algo.
+
+Lo que estas herramientas miden es si la escritura **se parece** a los patrones que producen las
+máquinas: frases de longitud pareja, ciertas expresiones de manual, cierta forma de matizar. Las
+personas también escriben así. Quien aprendió español o inglés como segunda lengua escribe así con
+más frecuencia, porque le enseñaron el registro formal y se mantiene dentro de él. Quien fue
+entrenado en la estructura de cinco párrafos escribe así. Quien es cuidadoso escribe así.
+
+**Que te marquen no es prueba de que hiciste nada.** Significa que un programa detectó patrones. Los
+programas detectan patrones en trabajos inocentes todo el tiempo.
+
+## Qué hace y qué no hace esta herramienta en concreto
+
+Publica con qué frecuencia se equivoca sobre escritura que se sabe humana — una cifra que casi
+ninguna herramienta de esta categoría dice sobre sí misma. En su corpus de noventa textos publicados
+antes de que existiera la escritura con IA, no marcó **ninguno** en su ajuste recomendado. Pero son
+noventa textos, y la lectura honesta es el rango alrededor de ese cero, no el cero: algo **por debajo
+de 4 de cada 100**.
+
+También hace algo que la mayoría se niega a hacer: **por debajo de su umbral respaldado no imprime
+ningún veredicto.** Una puntuación baja no es un certificado de que lo escribió una persona, y no
+pretende serlo. Una herramienta que no detectara nada también daría una puntuación baja.
+
+Tu trabajo no se sube a ningún sitio. Se analiza en el equipo de tu profesor y de ahí no sale.
+
+## Qué resuelve de verdad una duda
+
+Un número, no. **Una conversación sobre tu trabajo.**
+
+Si tu profesor te pregunta por un trabajo, probablemente pregunte cosas así:
+
+- *Escribiste esta expresión: ¿qué significa, con tus palabras?*
+- *¿Por qué elegiste este ejemplo y no otro?*
+- *¿Qué dejaste fuera, y por qué?*
+- *¿De dónde salió esta fuente? ¿Qué dice realmente?*
+
+No son preguntas trampa ni hay una respuesta correcta que memorizar. Quien escribió un texto puede
+hablar de las decisiones que hay en él. Quien no lo escribió, no puede. **Esa asimetría, y no una
+puntuación, es lo que resuelve estas situaciones** — por eso la conversación es lo importante y el
+programa no lo es.
+
+## Tres cosas que te protegen y casi no cuestan nada
+
+**Guarda tus borradores.** En lo que sea: un documento con historial de versiones, una carpeta con
+archivos fechados, lo que uses. El rastro de un trabajo haciéndose es la respuesta más completa a
+cualquier duda sobre él, y no cuesta ningún esfuerzo si simplemente no borras cosas.
+
+**Guarda tus fuentes.** No solo la cita: el PDF, el enlace, la página que leíste. Una de las pocas
+cosas que una máquina no puede falsificar es una fuente real que dice lo que afirmas que dice.
+
+**Pregunta antes, no después.** Si no sabes si una herramienta está permitida, pregunta. Toda norma
+tiene un borde, y preguntar por el borde nunca le ha costado nada a nadie. Usarla y esperar a ver qué
+pasa, sí.
+
+## Si te preguntan por tu trabajo
+
+**Que te pregunten no es una acusación.** Los profesores preguntan por muchos motivos.
+
+Responde con honestidad, también sobre cualquier herramienta de IA que hayas usado y para qué. En
+casi todas las normas el uso declarado está permitido, o en el peor caso pesa muchísimo menos que el
+no declarado. Lleva tus borradores, tus notas y tus fuentes; si los tienes, esto suele terminar en la
+misma reunión.
+
+Si sientes que la conversación va mal, haz dos preguntas, con calma:
+
+> *¿Qué exactamente de mi trabajo generó la duda?*
+>
+> *¿Qué tendría que mostrar para resolverla?*
+
+Las dos son razonables, y un proceso justo puede responder ambas. Si la única respuesta que recibes
+es *lo dijo el programa*, eso no basta para tomar una decisión sobre ti — y tu institución casi con
+seguridad tiene un procedimiento de apelación que dice lo mismo. Pídelo por escrito.
+
+## Y si sí usaste IA
+
+Dilo cuanto antes, y sé específico. Casi siempre sale mejor que esperar a que lo descubran — y sale
+mucho mejor que una negación que después se cae, que es lo que convierte una sanción pequeña en una
+grave.
+
+---
+
+Esta hoja describe [SignsOfAI](https://github.com/peopleworks/SignsofAI), una herramienta de código
+abierto que funciona totalmente sin conexión. Su tasa de error completa y el método están publicados
+en [`Docs/CALIBRATION.md`](../CALIBRATION.md). Puedes leerlos: no son secretos, y no están escritos
+solo para especialistas.

--- a/Docs/Teaching/syllabus.en.md
+++ b/Docs/Teaching/syllabus.en.md
@@ -1,0 +1,99 @@
+# Syllabus language you can paste
+
+Written to be copied into a course syllabus and changed to fit. Nothing here needs a licence, an
+attribution or our permission.
+
+The clauses come in three strengths. Pick one — mixing them produces a policy that contradicts
+itself, which is the most common way an AI-writing policy fails.
+
+Whichever you choose, the sentence that has to survive editing is this one: **a detector's score is
+never the reason for a decision about a student.** Everything else is negotiable.
+
+---
+
+## Option A — Disclosure
+
+*For courses where the tool is allowed and the skill being assessed is not drafting prose.*
+
+> You may use AI assistants for this course. If you use one, add a short note at the end of the
+> assignment saying which tool you used and what you used it for — brainstorming, outlining,
+> rewriting a paragraph, checking grammar, generating code. A note like *"I used an AI assistant to
+> restructure my second section and to check my citation formatting"* is complete and sufficient.
+>
+> Undisclosed use is what this policy is about. Disclosed use is not penalised and does not lower
+> your grade.
+>
+> I may run submitted work through an offline writing-analysis tool. Nothing it reports decides a
+> grade or triggers a penalty by itself. If something in your work raises a question, I will ask you
+> about your work before I reach any conclusion, and your answer counts for more than any tool's
+> output.
+
+## Option B — Process, not product
+
+*For courses where you want to keep assessing writing, and the most robust option available.*
+
+> This course assesses your thinking, and the assignment is only the visible end of it. Alongside
+> each major piece of work, keep your drafts, your notes, your sources and your outline. You may be
+> asked to walk me through them, or to talk through a section of your submitted work in office
+> hours.
+>
+> Being asked is not an accusation and carries no penalty. It is part of how work is assessed in
+> this course, and I may ask anyone.
+>
+> I may run submitted work through an offline writing-analysis tool. It produces no verdict, and no
+> score from it will ever be the basis of a decision about you. Its purpose is to tell me where to
+> read more carefully — the same thing my own eyes do, applied evenly to everyone's work rather than
+> only to the students I happen to wonder about.
+
+## Option C — Not permitted
+
+*For courses where the assignment is the writing itself. Say what is not allowed narrowly: a blanket
+"no AI" now bans the spellchecker, and a rule nobody can follow is a rule nobody respects.*
+
+> For the assignments in this course you may not use a generative AI tool to produce text you then
+> submit as your own — drafting sentences, paragraphs, or whole sections. Grammar and spelling
+> checkers, translation tools used on your own sentences, and search engines are all permitted.
+>
+> If you are unsure whether something falls on the wrong side of that line, ask me before you use
+> it. Asking has never cost a student anything in this course.
+>
+> Keep your drafts and notes for each assignment. If a question arises about a piece of work, I will
+> ask you to talk me through how you wrote it. That conversation, not any software, is how the
+> question gets settled.
+
+---
+
+## The clause worth adding to all three
+
+> **On detection tools.** No automated tool can determine who wrote a text, and every tool that
+> claims to can be wrong about a person who did nothing. The tool used in this course publishes how
+> often it is wrong about human writing, which is why it was chosen. It runs on my own machine: your
+> work is not uploaded, stored, or sent to any company.
+
+That last sentence is worth checking before you paste it, because it is untrue of most of this
+category. It is true of this tool: everything runs locally and no document, or any part of one,
+leaves the machine it is on.
+
+---
+
+## What not to write
+
+**Do not name a score.** A syllabus that says *"submissions scoring above 40 will be referred"*
+converts a statistical instrument into a rule, and you will have to enforce it against a student for
+whom it is wrong. That student exists: this tool flags human writing at some rate, and it publishes
+that rate rather than hiding it.
+
+**Do not promise you will not use a tool.** If you later use one, you have broken your own syllabus.
+Say what role a tool plays instead — and keep it to *where to look*, never *what to conclude*.
+
+**Do not require students to prove they wrote something.** It reverses the burden onto the person
+with the least power in the room, and it lands hardest on students who write in a second language,
+who write formally because they were taught to, and who cannot afford to lose an argument with an
+instructor. Ask them to *talk about their work* instead. Someone who wrote it can, and someone who
+did not, cannot.
+
+---
+
+Related: [`student-sheet.en.md`](student-sheet.en.md) — the one page for students.
+[`committee.en.md`](committee.en.md) — the procedure when a question becomes formal.
+[`../CALIBRATION.md`](../CALIBRATION.md) — the error rate, and how it was measured.

--- a/Docs/Teaching/syllabus.es.md
+++ b/Docs/Teaching/syllabus.es.md
@@ -1,0 +1,99 @@
+# Texto para el programa de la asignatura, listo para copiar
+
+Escrito para pegarse en un programa de asignatura y modificarse. Nada de esto necesita licencia,
+atribución ni permiso nuestro.
+
+Las cláusulas vienen en tres intensidades. Elija **una**: mezclarlas produce una política que se
+contradice a sí misma, que es la forma más común en que fracasa una norma sobre IA.
+
+Elija la que elija, la frase que debe sobrevivir a cualquier edición es esta: **la puntuación de un
+detector nunca es el motivo de una decisión sobre un estudiante.** Todo lo demás es negociable.
+
+---
+
+## Opción A — Declaración de uso
+
+*Para asignaturas donde la herramienta está permitida y lo que se evalúa no es redactar prosa.*
+
+> Puede usar asistentes de IA en esta asignatura. Si lo hace, añada una nota breve al final del
+> trabajo indicando qué herramienta usó y para qué: generar ideas, esquematizar, reescribir un
+> párrafo, revisar la gramática, generar código. Una nota como *«Usé un asistente de IA para
+> reorganizar mi segunda sección y revisar el formato de las citas»* es completa y suficiente.
+>
+> Esta norma trata sobre el uso **no declarado**. El uso declarado no se penaliza ni baja la
+> calificación.
+>
+> Puedo analizar los trabajos entregados con una herramienta de análisis de escritura que funciona
+> sin conexión. Nada de lo que informe decide por sí solo una calificación ni activa una sanción. Si
+> algo en su trabajo genera una duda, hablaré con usted sobre su trabajo antes de llegar a ninguna
+> conclusión, y lo que usted diga pesa más que cualquier resultado de un programa.
+
+## Opción B — El proceso, no el producto
+
+*Para asignaturas donde quiere seguir evaluando la escritura. Es la opción más sólida de las tres.*
+
+> Esta asignatura evalúa su pensamiento, y el trabajo entregado es solo su parte visible. Junto a
+> cada trabajo importante, conserve sus borradores, sus notas, sus fuentes y su esquema. Puedo
+> pedirle que me los muestre, o que comentemos alguna sección de su trabajo en tutoría.
+>
+> Que se lo pida no es una acusación ni conlleva ninguna penalización. Es parte de cómo se evalúa en
+> esta asignatura, y puedo pedírselo a cualquiera.
+>
+> Puedo analizar los trabajos con una herramienta que funciona sin conexión. No emite veredictos, y
+> ninguna puntuación suya será la base de una decisión sobre usted. Sirve para indicarme dónde leer
+> con más atención — lo mismo que hacen mis propios ojos, aplicado por igual a todos los trabajos y
+> no solo a los estudiantes sobre los que casualmente me pregunte algo.
+
+## Opción C — No permitido
+
+*Para asignaturas donde el trabajo es la escritura misma. Diga lo prohibido de forma estrecha: un «nada
+de IA» genérico prohíbe hasta el corrector ortográfico, y una norma que nadie puede cumplir es una
+norma que nadie respeta.*
+
+> En los trabajos de esta asignatura no puede usar una herramienta de IA generativa para producir
+> texto que luego entregue como propio: redactar frases, párrafos o secciones completas. Los
+> correctores ortográficos y gramaticales, los traductores aplicados a sus propias frases y los
+> buscadores están permitidos.
+>
+> Si no está seguro de si algo cae del lado equivocado de esa línea, pregúnteme antes de usarlo.
+> Preguntar nunca le ha costado nada a nadie en esta asignatura.
+>
+> Conserve sus borradores y notas de cada trabajo. Si surge una duda sobre un trabajo, le pediré que
+> me explique cómo lo escribió. Esa conversación, y no un programa, es lo que resuelve la duda.
+
+---
+
+## La cláusula que conviene añadir a las tres
+
+> **Sobre las herramientas de detección.** Ninguna herramienta automática puede determinar quién
+> escribió un texto, y toda herramienta que lo afirme puede equivocarse con una persona que no hizo
+> nada. La herramienta usada en esta asignatura **publica con qué frecuencia se equivoca** con
+> escritura humana, y por eso fue elegida. Funciona en mi propio equipo: su trabajo no se sube a
+> ningún sitio, no se almacena y no se envía a ninguna empresa.
+
+Vale la pena comprobar esa última frase antes de pegarla, porque es falsa en casi toda esta
+categoría de productos. En esta herramienta es cierta: todo ocurre localmente y ningún documento, ni
+fragmento de él, sale del equipo donde está.
+
+---
+
+## Lo que conviene no escribir
+
+**No fije una puntuación.** Un programa que dice *«los trabajos que superen 40 serán remitidos a
+comité»* convierte un instrumento estadístico en una norma, y tendrá que aplicarla contra un
+estudiante con el que se equivoca. Ese estudiante existe: esta herramienta marca escritura humana a
+cierta tasa, y publica esa tasa en lugar de esconderla.
+
+**No prometa que no usará ninguna herramienta.** Si luego la usa, ha incumplido su propio programa.
+Diga qué papel juega — y manténgalo en *dónde mirar*, nunca en *qué concluir*.
+
+**No exija a un estudiante que demuestre que escribió algo.** Invierte la carga sobre la persona con
+menos poder en la sala, y cae con más fuerza sobre quien escribe en una segunda lengua, sobre quien
+escribe formalmente porque así se lo enseñaron y sobre quien no puede permitirse perder una discusión
+con un profesor. Pídale que **hable de su trabajo**. Quien lo escribió, puede; quien no, no.
+
+---
+
+Relacionado: [`student-sheet.es.md`](student-sheet.es.md) — la página para el estudiante.
+[`committee.es.md`](committee.es.md) — el procedimiento cuando la duda se vuelve formal.
+[`../CALIBRATION.md`](../CALIBRATION.md) — la tasa de error y cómo se midió.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ✍︎ Signs of AI Writing
 
 [![Live demo](https://img.shields.io/badge/demo-live-brightgreen?logo=googlechrome&logoColor=white)](https://peopleworks.github.io/SignsofAI/)
-[![Windows app](https://img.shields.io/github/v/release/peopleworks/SignsofAI?filter=desktop-v*&label=Windows%20app&logo=windows&logoColor=white&color=0078D4)](https://github.com/peopleworks/SignsofAI/releases/tag/desktop-v0.1.0)
+[![Windows app](https://img.shields.io/github/v/release/peopleworks/SignsofAI?filter=desktop-v*&label=Windows%20app&logo=windows&logoColor=white&color=0078D4)](https://github.com/peopleworks/SignsofAI/releases?q=desktop&expanded=true)
 [![License: MIT](https://img.shields.io/github/license/peopleworks/SignsofAI?color=blue)](LICENSE)
 [![.NET 10](https://img.shields.io/badge/.NET-10-512BD4?logo=dotnet&logoColor=white)](https://dotnet.microsoft.com/)
 [![Blazor WebAssembly](https://img.shields.io/badge/Blazor-WASM-512BD4?logo=blazor&logoColor=white)](https://learn.microsoft.com/aspnet/core/blazor/)
@@ -14,7 +14,7 @@
 
 **[Try the live demo &rarr;](https://peopleworks.github.io/SignsofAI/)** — English & Spanish, runs 100% in your browser. No signup, and nothing leaves your device.
 
-**[Download the Windows app &rarr;](https://github.com/peopleworks/SignsofAI/releases/tag/desktop-v0.1.0)** — the same tool in a window. Nothing to install alongside it: the .NET runtime is bundled.
+**[Download the Windows app &rarr;](https://github.com/peopleworks/SignsofAI/releases?q=desktop&expanded=true)** — the same tool in a window. Nothing to install alongside it: the .NET runtime is bundled.
 
 ![Signs of AI Writing analyzing text live: the score climbs as AI tells accumulate, then every tell is highlighted with a fix](Docs/screenshots/analyze-live.gif)
 
@@ -75,6 +75,20 @@ The corpus is a JSON manifest anyone can extend, the tool that builds and measur
 `tools/SignsOfAI.Calibration`, and the whole thing re-runs in one command. See
 [`Docs/Calibration/README.md`](Docs/Calibration/README.md) — Spanish academic writing is the most
 wanted contribution.
+
+---
+
+## For teachers: the part that is not software
+
+A detector is not what you need first. **[`Docs/Teaching/`](Docs/Teaching/README.md)** is syllabus
+language you can paste, a one-page sheet to hand students before anything goes wrong, and a procedure
+for the day a question becomes formal — all bilingual, all free of any licence, attribution or
+permission.
+
+None of it requires this tool. It exists because the hard part of AI writing in a classroom was never
+detection; it is what you do on the morning you suspect something and have nobody to ask. All three
+documents are built on the same rule: **a score is never the reason for a decision about a student**,
+and a conversation about the work settles what no software can.
 
 ---
 

--- a/src/SignsOfAI.UI/wwwroot/i18n/en.json
+++ b/src/SignsOfAI.UI/wwwroot/i18n/en.json
@@ -6,7 +6,7 @@
   "batch.pagetitle": "Scan a folder — Signs of AI Writing",
   "batch.h1": "Scan a whole folder",
   "batch.tagline": "Point it at a folder of documents and it reads every one it can — PDF, Word, ODT, EPUB, RTF and plain text — on this machine. Nothing is uploaded.",
-  "batch.unavailable": "Folder scanning needs the <strong>desktop app</strong>: a browser tab is handed files, never a folder. <a href=\"https://github.com/peopleworks/SignsofAI/releases/tag/desktop-v0.1.0\">Download it here</a>, or use <em>Upload document</em> on the Analyze page for one file at a time.",
+  "batch.unavailable": "Folder scanning needs the <strong>desktop app</strong>: a browser tab is handed files, never a folder. <a href=\"https://github.com/peopleworks/SignsofAI/releases?q=desktop&expanded=true\">Download it here</a>, or use <em>Upload document</em> on the Analyze page for one file at a time.",
   "batch.choose": "Choose a folder",
   "batch.recursive": "Include subfolders",
   "batch.progress": "Reading {0} of {1}…",

--- a/src/SignsOfAI.UI/wwwroot/i18n/es.json
+++ b/src/SignsOfAI.UI/wwwroot/i18n/es.json
@@ -6,7 +6,7 @@
   "batch.pagetitle": "Analizar una carpeta — Señales de escritura IA",
   "batch.h1": "Analiza una carpeta entera",
   "batch.tagline": "Señálale una carpeta de documentos y lee todos los que puede —PDF, Word, ODT, EPUB, RTF y texto plano— en esta máquina. No se sube nada.",
-  "batch.unavailable": "Analizar carpetas requiere la <strong>app de escritorio</strong>: a una pestaña del navegador se le entregan archivos, nunca una carpeta. <a href=\"https://github.com/peopleworks/SignsofAI/releases/tag/desktop-v0.1.0\">Descárgala aquí</a>, o usa <em>Subir documento</em> en la página de análisis para ir de uno en uno.",
+  "batch.unavailable": "Analizar carpetas requiere la <strong>app de escritorio</strong>: a una pestaña del navegador se le entregan archivos, nunca una carpeta. <a href=\"https://github.com/peopleworks/SignsofAI/releases?q=desktop&expanded=true\">Descárgala aquí</a>, o usa <em>Subir documento</em> en la página de análisis para ir de uno en uno.",
   "batch.choose": "Elegir carpeta",
   "batch.recursive": "Incluir subcarpetas",
   "batch.progress": "Leyendo {0} de {1}…",


### PR DESCRIPTION
Mostly zero code. `Docs/Teaching/`, bilingual, written rather than translated.

- **Syllabus language** — three policies at different strengths, ready to paste, plus what *not* to write: never name a score, never require a student to prove they wrote something.
- **The student sheet** — one page addressed to students: what a flag means, what it does not, what protects them, and the two questions to ask calmly if a conversation goes badly.
- **Committee procedure** — assumes the hardest case, the student denies it. Sorts the material into checkable facts, a pattern score, and what the student says; only the first and last belong in a finding.

No licence, no attribution, no permission — they are meant to be pasted into other institutions' paperwork with somebody else's name on top.

**Why now.** Six bets have shipped and none of them is what a teacher reaches for on the morning they suspect something. Every distribution channel this project has used — a package registry, an MCP directory, a foundation application — contains no teachers. This is the first artefact aimed at one.

Each document is built so a decision made by following it survives the detector being removed from it entirely. The committee procedure quotes the uncomfortable half of our own calibration deliberately: **neither language supports a threshold on its own**, so a committee quoting the 4.1% aggregate at a student writing in Spanish makes the exact error this project criticises in everyone else.

**Also fixes a stale download.** Four links still pointed at `desktop-v0.1.0`, including both translations shipped inside the web app. The badge rendered 0.3.0 and sent whoever clicked it to a build with no PDF reading, no folder scan and no report. They now point at the desktop release listing, which cannot go stale on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)