### PR TITLE
Count the tools the container actually starts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,6 @@ WORKDIR /app
 COPY --from=build /app ./
 
 # stdio transport: the client speaks JSON-RPC over stdin/stdout, so nothing is
-# exposed on a port and there is no health endpoint to probe. Seven of the nine
+# exposed on a port and there is no health endpoint to probe. Eight of the ten
 # tools never open a socket at all.
 ENTRYPOINT ["dotnet", "SignsOfAI.Mcp.dll"]


### PR DESCRIPTION
One-line comment fix. The Dockerfile claimed *seven of the nine tools* never open a socket; it has been ten tools since `write_report` shipped in 0.4.0, and eight of them never open one — only `check_paraphrase` and `measure_predictability` can, both opt-in.

Noticed while checking why Glama still lists nine tools after a sync: its metadata comes from the repository and refreshes immediately, but the tool list requires rebuilding and starting the container, which lags. The build spec needs no change — the Dockerfile builds from source, so the rebuild will find all ten.

This comment is read by people deciding whether to trust a container that analyses student coursework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)