### PR TITLE
Say exactly what can leave the device, because "only" was wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![NuGet MCP](https://img.shields.io/nuget/v/SignsOfAI.Mcp?logo=nuget&label=MCP%20server)](https://www.nuget.org/packages/SignsOfAI.Mcp)
 [![Available on CodeGuilds](https://img.shields.io/badge/Available_on-CodeGuilds-6366f1?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0id2hpdGUiIGQ9Ik0xMiAyTDIgN2wxMCA1IDEwLTV6TTIgMTdsMTAgNSAxMC01TTIgMTJsMTAgNSAxMC01Ii8+PC9zdmc+)](https://codeguilds.dev/packages/signsofai)
 
-**[Try the live demo &rarr;](https://peopleworks.github.io/SignsofAI/)** — English & Spanish, runs 100% in your browser. No signup, and nothing leaves your device.
+**[Try the live demo &rarr;](https://peopleworks.github.io/SignsofAI/)** — English & Spanish, runs in your browser. No signup, and the analysis uploads nothing.
 
 **[Download the Windows app &rarr;](https://github.com/peopleworks/SignsofAI/releases?q=desktop&expanded=true)** — the same tool in a window. Nothing to install alongside it: the .NET runtime is bundled.
 
@@ -31,8 +31,19 @@ A free, privacy-first toolkit for **academic and writing integrity**. It does tw
    and surfaces the passages they share — verbatim copies, **reworded paraphrases** (even across
    languages), and a whole-cohort overview — as **evidence a human judges**. Not a black-box verdict.
 
-> 🔒 **Almost everything runs 100% in your browser. Your documents never leave your device.**
-> The only exception is the optional paraphrase check, which is strictly opt-in and clearly disclosed.
+> 🔒 **The analysis runs entirely in your browser, and nothing is uploaded to run it.** No account, no
+> telemetry, no server that sees your text.
+>
+> Four features can send text off the device, and **not one of them runs unless you turn it on**, each
+> disclosed in the interface at the moment you choose it: the **paraphrase check** and the
+> **perplexity measurement** (both call a server you or we host), the **live rewrite** when you supply
+> your own API key — the key stays on your device, the text goes to the provider you picked — and the
+> optional **web spot-check** for a distinctive phrase, which exists only if the operator configured a
+> search provider.
+>
+> Everything else — every rule, the score, the character scan, the citation cross-check, the writer
+> baseline, the report — is computed locally and stays there. In the desktop app, the perplexity
+> measurement is local too.
 
 Built with **.NET 10** and **Blazor WebAssembly** by **Pedro Hernández (PeopleWorks)**, [Microsoft MVP for .NET](https://mvp.microsoft.com/en-US/mvp/profile/24060a02-dbc6-44ec-bca5-c213ff9835c5) — for the .NET and Microsoft developer community, *por y para la comunidad educativa*.
 

--- a/src/SignsOfAI.Mcp/README.md
+++ b/src/SignsOfAI.Mcp/README.md
@@ -18,11 +18,13 @@ Built on the official [`ModelContextProtocol`](https://www.nuget.org/packages/Mo
 | `inspect_characters` | Characters typing cannot produce — zero-width, homoglyphs, hidden tag characters — with the exact line and column of each | 🖥️ offline |
 | `check_citations` | Where a document contradicts its **own** reference list: a source cited but never listed, one DOI on two works, a year that has not happened | 🖥️ offline |
 | `compare_to_baseline` | How a piece sits against the same person's earlier work (Burrows's Delta) — measured on **their** variation, never a verdict about who wrote it | 🖥️ offline |
+| `write_report` | The whole analysis as a document a person can keep, forward, or take to a committee — with the tool's own error rate printed on it | 🖥️ offline |
 | `measure_predictability` | Perplexity — how predictable/generic a model finds the phrasing | ☁️ server |
 | `check_paraphrase` | Reworded/translated copies via sentence embeddings (EmbeddingGemma) | ☁️ server |
 
-The first seven run **entirely on the machine** — the text never leaves it. The last two **send the text**
-to the SignsOfAI server (their descriptions disclose this); see [Server tools](#server-tools-optional).
+Eight of the ten run **entirely on the machine** — the text never leaves it. The two marked ☁️ **send
+the text** to the SignsOfAI server (their descriptions disclose this); see
+[Server tools](#server-tools-optional).
 
 ## Install
 


### PR DESCRIPTION
This commit was written on 5 Aug, approved, and **never reached `main`** — it was part of PR #45,
which merged while it was still in flight. `main` today still carries the sentence this fixes.

That is the second time a merge has silently dropped work on this repository, so it is worth naming
the check that caught it: `git merge-base --is-ancestor <sha> origin/main`. The PR badge said merged
and was green. The commit was not there.

## What it fixes

`README.md` claimed:

> The only exception is the optional paraphrase check, which is strictly opt-in and clearly disclosed.

There are **four** features that can send text off the device, not one:

| Feature | Client |
|---|---|
| Paraphrase check | `EmbeddingClient` |
| Predictability (perplexity) | `PerplexityClient` |
| Live rewrite (bring your own key) | `HumanizerService` — the key stays, the text goes |
| Web spot-check | `WebCheckClient` |

Every one of them is off until switched on, and each discloses itself in the interface, so the
spirit of the claim held. The letter did not. A privacy promise broader than the code is exactly
what this project criticises in other tools, and it is the one sentence a reader is entitled to
take literally.

Also corrects `src/SignsOfAI.Mcp/README.md`, which still said "the first seven" tools while listing
nine.

No behaviour change; documentation only.