### PR TITLE
Write down the Glama build values, which lived nowhere but in Glama

### DIFF
--- a/Docs/glama-build.md
+++ b/Docs/glama-build.md
@@ -1,0 +1,74 @@
+# The Glama build configuration
+
+Glama lists this MCP server and verifies it by **building and starting it themselves**. That build
+is not driven by the repository's `Dockerfile`: it is a form under *Admin → Dockerfile* on
+<https://glama.ai/mcp/servers/@peopleworks/SignsofAI>, and Glama generates a Dockerfile from the
+fields. The repository's own `Dockerfile` is a separate, simpler thing for anyone who wants to run
+the server in a container by hand.
+
+**This file exists because those form values lived nowhere else.** On 2026-08-10 they were
+overwritten with another project's, and the only surviving copy was a screenshot somebody happened
+to have taken. A configuration that a third party stores for you is a configuration you do not have.
+
+## The values
+
+**Base image** `debian:trixie-slim` — **Node.js** `26` — **Python** `3.14`
+
+**Build steps**
+
+```json
+[
+  "apt-get update && apt-get install -y --no-install-recommends libicu-dev && rm -rf /var/lib/apt/lists/*",
+  "curl -sSL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh",
+  "bash dotnet-install.sh --channel 10.0 --install-dir ./dotnet",
+  "./dotnet/dotnet publish src/SignsOfAI.Mcp/SignsOfAI.Mcp.csproj -c Release -o ./out"
+]
+```
+
+**CMD arguments**
+
+```json
+["mcp-proxy", "--", "./dotnet/dotnet", "./out/SignsOfAI.Mcp.dll"]
+```
+
+**Environment variables JSON schema**
+
+```json
+{
+  "properties": {
+    "SIGNSOFAI_API_ENDPOINT": {
+      "description": "Endpoint for the optional server features (predictability and paraphrase check). If not set, those tools are unavailable.",
+      "type": "string"
+    }
+  },
+  "required": [],
+  "type": "object"
+}
+```
+
+**Placeholder parameters** `{}` — the server starts with no credentials, so there is nothing to fake.
+
+**Pinned commit SHA** — leave **empty**. See below.
+
+## Three things that are easy to get wrong
+
+**`libicu-dev` is the first build step, and it is not optional.** `debian:trixie-slim` ships no ICU
+and .NET dies at startup without it. The tempting fix is
+`DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1`, which makes the build pass and **silently changes how
+Spanish text is compared and cased** — in a product whose whole differentiator is that it treats
+Spanish as a first language. Install the library; never set that variable.
+
+**Leave the pinned SHA empty.** A pin is a promise to keep publishing whatever that commit said. On
+2026-08-10 the form was pinned to `020554d`, from the day before, so a rebuild would have shipped a
+report that announced a tidy bibliography as a source contradiction — a defect fixed that morning.
+If a pin is ever needed, it is a temporary measure with a date attached, not a default.
+
+**stdio, so there is no port.** The client speaks JSON-RPC over stdin and stdout. `mcp-proxy` in the
+CMD is Glama's own shim that fronts a stdio server for their checks. Nothing listens on a socket,
+so any field asking for a port or a health endpoint stays blank.
+
+## Related
+
+- `Dockerfile` in the repository root — the hand-run container, unrelated to this form.
+- `src/SignsOfAI.Mcp/.mcp/server.json` — the MCP registry manifest, a third and separate place the
+  version has to be raised on release.


### PR DESCRIPTION
Glama does not build from this repository's `Dockerfile`. It builds from a form in its own admin panel, and today those fields were overwritten. **The only surviving copy of the correct values was a screenshot somebody happened to have taken.**

A configuration a third party stores for you is a configuration you do not have.

`Docs/glama-build.md` records the base image, build steps, CMD, environment schema and placeholder parameters verbatim, plus the three things that are easy to get wrong — each of which has already cost something:

- **`libicu-dev` is the first build step and not optional.** `debian:trixie-slim` ships no ICU and .NET dies at startup without it. The tempting fix is `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT`, which makes the build pass and **silently changes how Spanish text is compared and cased** — in the product whose differentiator is treating Spanish as a first language.
- **The pinned SHA should be empty.** It was set to `020554d`, from yesterday, so a rebuild would have republished the report that announces a tidy bibliography as a source contradiction — fixed this morning in #53. A pin is a promise to keep shipping whatever that commit said.
- **stdio, so no port and no health endpoint.** `mcp-proxy` in the CMD is Glama's own shim for their checks.

## Also worth knowing, found while looking

The public listing is **healthy** — A/A/A, eight tools, no failure indicator — so nothing needs rescuing there. But it is **six days stale**: it still shows `0.3.0` from 2026-08-04, and its own build history already carried a failure from 2026-08-05 10:51, before today's. NuGet and the MCP registry are at `0.4.0`.

That also explains the tool count: eight is what `0.3.0` exposed.

A successful rebuild against current `main` brings the listing up to date and picks up this morning's fixes at the same time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)