### PR TITLE
Survive the 503 that made a healthy deployment look like an outage

### DIFF
--- a/src/SignsOfAI.Web/wwwroot/index.html
+++ b/src/SignsOfAI.Web/wwwroot/index.html
@@ -37,7 +37,10 @@
     </div>
     <script src="_content/SignsOfAI.UI/js/lang.js"></script>
     <script src="_content/SignsOfAI.UI/js/share-card.js"></script>
-    <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
+    <!-- autostart="false" so boot.js can start Blazor itself: it retries a boot file the
+         server fails to hand over, and explains the failure if it still will not come. -->
+    <script src="_framework/blazor.webassembly#[.{fingerprint}].js" autostart="false"></script>
+    <script src="js/boot.js"></script>
 </body>
 
 </html>

--- a/src/SignsOfAI.Web/wwwroot/js/boot.js
+++ b/src/SignsOfAI.Web/wwwroot/js/boot.js
@@ -1,0 +1,129 @@
+// Starting the app, out loud when it fails.
+//
+// The runtime arrives as ~50 separate files, each one pinned by a SHA-256 in the boot manifest.
+// GitHub Pages answers one of them with a 503 now and then. The browser hashes whatever body did
+// arrive — an error page, not the assembly — the integrity check fails, and Blazor gives up for
+// good. What the visitor sees is the loading circle, forever, with no message: the failure happens
+// before Blazor has an error UI to show. That is how this reached us, as "the app is down", when
+// every file on the server was intact.
+//
+// So: retry the download before believing it, and if it still will not come, say so.
+(function () {
+    const ATTEMPTS = 3;
+    const BACKOFF_MS = [400, 1200];
+
+    // The .NET runtime's own scripts are ES modules — they have to be handed back as a URL for the
+    // import to work, so a Response would break them. Those keep the default loader.
+    const NOT_OURS = 'dotnetjs';
+
+    let lastFailure = null;
+
+    async function fetchWithRetry(url, integrity) {
+        for (let attempt = 0; attempt < ATTEMPTS; attempt++) {
+            if (attempt > 0) {
+                await new Promise(done => setTimeout(done, BACKOFF_MS[attempt - 1] ?? 1200));
+            }
+            try {
+                const response = await fetch(url, {
+                    // Handing fetch the manifest's own hash keeps the guarantee we would otherwise
+                    // be dropping: returning a Response from loadBootResource takes the integrity
+                    // check away from Blazor, so the browser has to do it here instead.
+                    integrity: integrity || undefined,
+                    // A first try may legitimately come from the browser cache. A retry may not —
+                    // if what we hold is a truncated or stale body, asking for it again is useless.
+                    cache: attempt === 0 ? 'default' : 'reload',
+                });
+                if (response.ok) return response;
+                lastFailure = { url, reason: `HTTP ${response.status}` };
+            } catch (error) {
+                // An integrity mismatch rejects here too, which is the case we are actually chasing:
+                // a 503 body hashes to something else, and retrying is exactly the right answer.
+                lastFailure = { url, reason: String(error && error.message || error) };
+            }
+        }
+        // Blazor does not reject Blazor.start() when a boot file will not come — the failure
+        // surfaces as an unhandled rejection deep in mono_download_assets, which is why the
+        // spinner used to spin for good. We are the ones who know the download is out of tries,
+        // so the explanation is written from here rather than from a .catch that never runs.
+        reportFailure();
+        throw new Error(`${lastFailure.reason} for ${lastFailure.url}`);
+    }
+
+    // The app has not started, so Blazor cannot render this and its own error UI is not wired yet.
+    // It also styles itself: app.css is a separate request, and a page that is explaining a failed
+    // download should not depend on one more download having worked. The custom properties are used
+    // where they exist and fall back to their light-theme values where they do not.
+    let reported = false;
+
+    function reportFailure(error) {
+        // Several assets can fail in the same run; the first explanation is the one that stands.
+        if (reported) return;
+        reported = true;
+
+        const spanish = (navigator.language || '').toLowerCase().startsWith('es');
+        const copy = spanish ? {
+            title: 'No se pudo terminar de cargar',
+            body: 'Un archivo de la aplicación no llegó. Casi siempre es un fallo pasajero del ' +
+                  'servidor, no un problema de tu texto ni de tu navegador. Nada de lo que ' +
+                  'escribiste salió de tu equipo — la aplicación ni siquiera llegó a arrancar.',
+            retry: 'Reintentar',
+            details: 'Detalle técnico',
+        } : {
+            title: "Couldn't finish loading",
+            body: 'One of the application files did not arrive. This is almost always a passing ' +
+                  'server fault, not a problem with your text or your browser. Nothing you typed ' +
+                  'left your machine — the application never got as far as starting.',
+            retry: 'Try again',
+            details: 'Technical detail',
+        };
+
+        const app = document.getElementById('app');
+        if (!app) return;
+
+        app.innerHTML = '';
+        const panel = document.createElement('div');
+        panel.setAttribute('role', 'alert');
+        panel.style.cssText =
+            'max-width:34rem;margin:12vh auto;padding:1.5rem;border-radius:14px;' +
+            'border:1px solid var(--border,#e2e6ea);background:var(--surface,#fff);' +
+            'color:var(--text,#1a1d21);font:1rem/1.5 system-ui,-apple-system,Segoe UI,sans-serif;';
+
+        const title = document.createElement('h1');
+        title.textContent = copy.title;
+        title.style.cssText = 'margin:0 0 .6rem;font-size:1.25rem;';
+
+        const body = document.createElement('p');
+        body.textContent = copy.body;
+        body.style.cssText = 'margin:0 0 1.2rem;color:var(--text-muted,#5b6470);';
+
+        const retry = document.createElement('button');
+        retry.type = 'button';
+        retry.textContent = copy.retry;
+        retry.style.cssText =
+            'padding:.55rem 1.1rem;border:0;border-radius:8px;cursor:pointer;font:inherit;' +
+            'background:var(--brand,#2563eb);color:var(--brand-ink,#fff);';
+        retry.addEventListener('click', () => window.location.reload());
+
+        const details = document.createElement('details');
+        details.style.cssText = 'margin-top:1.2rem;font-size:.82rem;color:var(--text-muted,#5b6470);';
+        const summary = document.createElement('summary');
+        summary.textContent = copy.details;
+        summary.style.cssText = 'cursor:pointer;';
+        const pre = document.createElement('pre');
+        // textContent, not innerHTML: the URL comes back from the network and is never markup here.
+        pre.textContent = lastFailure
+            ? `${lastFailure.reason}\n${lastFailure.url}`
+            : String(error && error.message || error);
+        pre.style.cssText = 'white-space:pre-wrap;word-break:break-all;margin:.5rem 0 0;';
+        details.append(summary, pre);
+
+        panel.append(title, body, retry, details);
+        app.append(panel);
+    }
+
+    Blazor.start({
+        loadBootResource(type, name, defaultUri, integrity) {
+            return type === NOT_OURS ? undefined : fetchWithRetry(defaultUri, integrity);
+        },
+    }).catch(reportFailure);
+})();

--- a/tests/SignsOfAI.Core.Tests/WebBootTests.cs
+++ b/tests/SignsOfAI.Core.Tests/WebBootTests.cs
@@ -1,0 +1,92 @@
+using Xunit;
+
+namespace SignsOfAI.Core.Tests;
+
+/// <summary>
+/// Guards how the web app starts, in <c>src/SignsOfAI.Web/wwwroot/</c>.
+///
+/// The runtime arrives as roughly fifty files, each pinned by a SHA-256 in the boot manifest. When
+/// the host answers one of them with a 503, the browser hashes the error page instead of the
+/// assembly, the integrity check fails, and Blazor stops for good — before it owns an error UI, so
+/// the visitor gets the loading circle and nothing else. That is a healthy deployment reading as an
+/// outage, and it is how it was first reported to us.
+///
+/// <c>boot.js</c> retries, and says so when the retry does not help. Three things in it fail
+/// silently if a later edit gets them wrong, which is why they are asserted here rather than left
+/// to a reviewer: the script has to run *after* Blazor is defined, it has to keep handing the
+/// manifest hash to <c>fetch</c>, and it has to leave the runtime's own ES modules alone.
+/// </summary>
+public class WebBootTests
+{
+    private static readonly string WebRoot = FindWebRoot();
+    private static readonly string IndexHtml =
+        File.ReadAllText(Path.Combine(WebRoot, "index.html"));
+    private static readonly string BootJs =
+        File.ReadAllText(Path.Combine(WebRoot, "js", "boot.js"));
+
+    [Fact]
+    public void Blazor_does_not_autostart_so_boot_js_can_supply_the_retry()
+    {
+        Assert.Contains("blazor.webassembly#[.{fingerprint}].js\" autostart=\"false\"", IndexHtml);
+    }
+
+    [Fact]
+    public void Boot_script_is_loaded_after_blazor_defines_itself()
+    {
+        var blazor = IndexHtml.IndexOf("blazor.webassembly#[.{fingerprint}].js", StringComparison.Ordinal);
+        var boot = IndexHtml.IndexOf("js/boot.js", StringComparison.Ordinal);
+
+        Assert.True(blazor >= 0, "index.html no longer loads the Blazor WebAssembly script.");
+        Assert.True(boot >= 0, "index.html no longer loads js/boot.js, so nothing starts the app.");
+        Assert.True(boot > blazor,
+            "boot.js must come after the Blazor script: it calls Blazor.start(), and window.Blazor " +
+            "does not exist until that script has run.");
+    }
+
+    [Fact]
+    public void Boot_script_starts_blazor_through_a_boot_resource_loader()
+    {
+        Assert.Contains("Blazor.start(", BootJs);
+        Assert.Contains("loadBootResource", BootJs);
+    }
+
+    [Fact]
+    public void Retry_still_hands_the_manifest_hash_to_fetch()
+    {
+        // Returning a Response from loadBootResource takes the integrity check away from Blazor.
+        // Dropping `integrity` here would therefore not fail anything — it would quietly stop
+        // verifying every assembly the app loads, which is the opposite of what this file is for.
+        Assert.Contains("integrity: integrity", BootJs);
+    }
+
+    [Fact]
+    public void Runtime_modules_are_left_to_the_default_loader()
+    {
+        // The dotnet.js family is imported as ES modules, which needs a URL. Answer those with a
+        // Response and the import fails — turning a fix for rare 503s into a permanent breakage.
+        Assert.Contains("dotnetjs", BootJs);
+        Assert.Contains("undefined", BootJs);
+    }
+
+    [Theory]
+    // The app picks its language from the browser, and this panel renders before the app exists,
+    // so it carries its own copy. English-only here would be the #36 bug in a new place.
+    [InlineData("No se pudo terminar de cargar")]
+    [InlineData("Couldn't finish loading")]
+    public void Failure_panel_speaks_both_languages(string phrase)
+    {
+        Assert.Contains(phrase, BootJs);
+    }
+
+    private static string FindWebRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "SignsOfAI.slnx")))
+            dir = dir.Parent;
+
+        Assert.NotNull(dir);
+        var path = Path.Combine(dir.FullName, "src", "SignsOfAI.Web", "wwwroot");
+        Assert.True(Directory.Exists(path), $"Expected the web wwwroot at {path}");
+        return path;
+    }
+}


### PR DESCRIPTION
A user reported the app was down. It was not.

## What was actually wrong

All 53 framework assets serve `200` and every SHA-256 matches the boot manifest byte for byte — the file in the report included:

| | |
|---|---|
| declared in the manifest | `sha256-gx2VPgq3h4wLjW7iWPZwsBNKDDRcGzmOad/1nUBl9nE=` |
| served by GitHub Pages | `gx2VPgq3h4wLjW7iWPZwsBNKDDRcGzmOad/1nUBl9nE=` |

GitHub Pages answered one file with a passing `503`. The browser hashed the error page instead of the assembly, got `J5J7M+…`, SRI blocked it, and Blazor abandoned startup for good.

One blip on any of fifty-three files bricked the load. And there was nothing to see: the failure happens *before* Blazor owns an error UI, so the visitor gets the loading circle and no message. That is why the report arrived as "the app is down" rather than "`System.IO.Compression` did not arrive" — the same lesson as the version in the desktop footer. A user can only report what the app is willing to tell them.

## What this changes

`wwwroot/js/boot.js`, plus `autostart="false"` so it can start Blazor itself:

1. **Retry** — three attempts with backoff; the retries use `cache: 'reload'`, since asking the cache again for a body we already know is bad is useless.
2. **A panel that speaks**, in English and Spanish, when the retry does not help. It names the file that never came, says the reader's text never left their machine, and offers to try again.

**The integrity guarantee is kept, not traded away.** Returning a `Response` from `loadBootResource` takes the check away from Blazor, so the manifest hash is handed to `fetch` and the browser enforces it instead. The runtime's own ES modules are left to the default loader — answering those with a `Response` breaks the import.

## Verified by reproduction, not by argument

Against a local server that 503s that same asset, in a real browser:

| Scenario | Before | After |
|---|---|---|
| Two 503s (the production case) | spinner, forever | **boots** — console prints the reporter's three lines verbatim, then recovers |
| 503 that never yields | spinner, forever | the panel, naming `System.IO.Compression….wasm`, EN and ES |
| No failures | boots | boots, 0 console errors |

One finding worth keeping: **`Blazor.start()` does not reject** when a boot file will not come — the failure surfaces as an unhandled rejection inside `mono_download_assets`. My first attempt hung the panel off a `.catch` that never runs; it was caught by testing the permanent-failure case, and the explanation is now written from the retry loop, which is what knows it is out of tries.

## Tests

410 green. Seven new in `WebBootTests`, guarding only what breaks silently: script order (`Blazor` must exist before `boot.js` runs), that `integrity` is still handed to `fetch` (dropping it would fail nothing and quietly stop verifying every assembly), that the runtime modules stay out of the interceptor, and that the panel still speaks both languages.

## Scope

Web only. The desktop host has its own `index.html` and loads from local disk, where there is no 503 to survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015PEbbiYSNPw7jE3LrPNhyF
