### PR TITLE
The page for teachers was still showing a corpus of ninety and a rate of zero

### DIFF
--- a/Docs/Calibration/corpus.json
+++ b/Docs/Calibration/corpus.json
@@ -2965,7 +2965,7 @@
       "doi": null,
       "file": "wp-en-1002690535.txt",
       "sha256": "47596bb5ad5a29a0e2542826768ac0c7756a5b184326d870e120606e5314d384",
-      "note": "Revision of \"Kalvan series\" as of 2021-01-25T17:13:21Z, before generative models."
+      "note": "Revision of \"Kalvan series\" as of 2021-01-25T17:13:21Z, before 2022."
     },
     {
       "id": "wp-en-1004693610",
@@ -2977,7 +2977,7 @@
       "doi": null,
       "file": "wp-en-1004693610.txt",
       "sha256": "b4989022ea4726ae5099b9aa290d7f5a5b2377e504bdee4b849a1a597a3d4144",
-      "note": "Revision of \"Breddan Aerodrome\" as of 2021-02-03T22:14:38Z, before generative models."
+      "note": "Revision of \"Breddan Aerodrome\" as of 2021-02-03T22:14:38Z, before 2022."
     },
     {
       "id": "wp-en-1005496755",
@@ -2989,7 +2989,7 @@
       "doi": null,
       "file": "wp-en-1005496755.txt",
       "sha256": "6047aeac206994b22c95a0dc03273adea64f27c87454af233e42877a6d7511c3",
-      "note": "Revision of \"Persian verbs\" as of 2021-02-07T23:42:07Z, before generative models."
+      "note": "Revision of \"Persian verbs\" as of 2021-02-07T23:42:07Z, before 2022."
     },
     {
       "id": "wp-en-1010972751",
@@ -3001,7 +3001,7 @@
       "doi": null,
       "file": "wp-en-1010972751.txt",
       "sha256": "ff81adf4aa2c22fd51d21a0db5dcc21e748d0282312e434fbea626f809b4d042",
-      "note": "Revision of \"Austin Deasy\" as of 2021-03-08T09:45:40Z, before generative models."
+      "note": "Revision of \"Austin Deasy\" as of 2021-03-08T09:45:40Z, before 2022."
     },
     {
       "id": "wp-en-1016567157",
@@ -3013,7 +3013,7 @@
       "doi": null,
       "file": "wp-en-1016567157.txt",
       "sha256": "4219d921559f301d15f83aade780549dbfbee81a8e716d01cdffa1a976b21e96",
-      "note": "Revision of \"George C. Howard\" as of 2021-04-07T21:17:51Z, before generative models."
+      "note": "Revision of \"George C. Howard\" as of 2021-04-07T21:17:51Z, before 2022."
     },
     {
       "id": "wp-en-1017552036",
@@ -3025,7 +3025,7 @@
       "doi": null,
       "file": "wp-en-1017552036.txt",
       "sha256": "3c9138e72ae03b3fd8c263c8d3a1fdad525421f2fa0f6b7887f1d9b70e4d2352",
-      "note": "Revision of \"Scott West\" as of 2021-04-13T12:20:12Z, before generative models."
+      "note": "Revision of \"Scott West\" as of 2021-04-13T12:20:12Z, before 2022."
     },
     {
       "id": "wp-en-1019238083",
@@ -3037,7 +3037,7 @@
       "doi": null,
       "file": "wp-en-1019238083.txt",
       "sha256": "35a95911d83abdbb2500ebc75923b14e9b7c4efed4f234af3a87796a43729c66",
-      "note": "Revision of \"SMS S115\" as of 2021-04-22T07:05:47Z, before generative models."
+      "note": "Revision of \"SMS S115\" as of 2021-04-22T07:05:47Z, before 2022."
     },
     {
       "id": "wp-en-1020890569",
@@ -3049,7 +3049,7 @@
       "doi": null,
       "file": "wp-en-1020890569.txt",
       "sha256": "e6a272432b153dd33b8f4f31fd18447c9cf41ffecc2787ca11980d0de17e1f51",
-      "note": "Revision of \"Hurricane Tico\" as of 2021-05-01T17:06:13Z, before generative models."
+      "note": "Revision of \"Hurricane Tico\" as of 2021-05-01T17:06:13Z, before 2022."
     },
     {
       "id": "wp-en-1021715253",
@@ -3061,7 +3061,7 @@
       "doi": null,
       "file": "wp-en-1021715253.txt",
       "sha256": "7a3832e8fa89f570d5a825b9040e12bb0e1bd3e72d5883f062b8b2322349a466",
-      "note": "Revision of \"Game farm\" as of 2021-05-06T08:17:29Z, before generative models."
+      "note": "Revision of \"Game farm\" as of 2021-05-06T08:17:29Z, before 2022."
     },
     {
       "id": "wp-en-1021886472",
@@ -3073,7 +3073,7 @@
       "doi": null,
       "file": "wp-en-1021886472.txt",
       "sha256": "2cae0fbc6c870867b3296cf296fc721b0e49d967afd2220c4422360f98fef512",
-      "note": "Revision of \"Terence Conran\" as of 2021-05-07T06:39:26Z, before generative models."
+      "note": "Revision of \"Terence Conran\" as of 2021-05-07T06:39:26Z, before 2022."
     },
     {
       "id": "wp-en-1023079884",
@@ -3085,7 +3085,7 @@
       "doi": null,
       "file": "wp-en-1023079884.txt",
       "sha256": "b02208659020978f7447e7911d920ff0f32c17d417bac0a90fb62b08e90ceb76",
-      "note": "Revision of \"Toyota Land Cruiser Prado\" as of 2021-05-14T07:30:50Z, before generative models."
+      "note": "Revision of \"Toyota Land Cruiser Prado\" as of 2021-05-14T07:30:50Z, before 2022."
     },
     {
       "id": "wp-en-1023913723",
@@ -3097,7 +3097,7 @@
       "doi": null,
       "file": "wp-en-1023913723.txt",
       "sha256": "05a8cfaa58a09d3424472b626bfaac345d54a42251c0dbba89943707ce4c4d21",
-      "note": "Revision of \"Telemetry\" as of 2021-05-19T02:01:22Z, before generative models."
+      "note": "Revision of \"Telemetry\" as of 2021-05-19T02:01:22Z, before 2022."
     },
     {
       "id": "wp-en-1023959915",
@@ -3109,7 +3109,7 @@
       "doi": null,
       "file": "wp-en-1023959915.txt",
       "sha256": "ad1769b8db4afab0d3f1068ec0816847e793d980211b2173b7029df5c6b51349",
-      "note": "Revision of \"Censorship of Facebook\" as of 2021-05-19T09:20:02Z, before generative models."
+      "note": "Revision of \"Censorship of Facebook\" as of 2021-05-19T09:20:02Z, before 2022."
     },
     {
       "id": "wp-en-1024207992",
@@ -3121,7 +3121,7 @@
       "doi": null,
       "file": "wp-en-1024207992.txt",
       "sha256": "06fc69dc59a803c77f456c1b4a9821bf8529e3465ad4d59ae41aa6fd2077d30e",
-      "note": "Revision of \"Robotron Z1013\" as of 2021-05-20T19:09:54Z, before generative models."
+      "note": "Revision of \"Robotron Z1013\" as of 2021-05-20T19:09:54Z, before 2022."
     },
     {
       "id": "wp-en-1024922915",
@@ -3133,7 +3133,7 @@
       "doi": null,
       "file": "wp-en-1024922915.txt",
       "sha256": "a4aa487f55553431e7305aca712c4cc6e1b5a665ec3321191058e2753c08917a",
-      "note": "Revision of \"Single Bullet Theory (metal band)\" as of 2021-05-24T19:22:10Z, before generative models."
+      "note": "Revision of \"Single Bullet Theory (metal band)\" as of 2021-05-24T19:22:10Z, before 2022."
     },
     {
       "id": "wp-en-1025398061",
@@ -3145,7 +3145,7 @@
       "doi": null,
       "file": "wp-en-1025398061.txt",
       "sha256": "b0e7ea680237eab3514f047a66d73687735f59b9f7fec503188d166e301d316a",
-      "note": "Revision of \"Brontë family\" as of 2021-05-27T10:07:52Z, before generative models."
+      "note": "Revision of \"Brontë family\" as of 2021-05-27T10:07:52Z, before 2022."
     },
     {
       "id": "wp-en-1025409680",
@@ -3157,7 +3157,7 @@
       "doi": null,
       "file": "wp-en-1025409680.txt",
       "sha256": "4bbc3e5da5263f2f2db65186953d35c90da75209ce93b9535abdfc8fd48fcb12",
-      "note": "Revision of \"Granada Hills, Los Angeles\" as of 2021-05-27T11:41:03Z, before generative models."
+      "note": "Revision of \"Granada Hills, Los Angeles\" as of 2021-05-27T11:41:03Z, before 2022."
     },
     {
       "id": "wp-en-1025671620",
@@ -3169,7 +3169,7 @@
       "doi": null,
       "file": "wp-en-1025671620.txt",
       "sha256": "c832e7064b1694f753f6cf09e4c1ee7d08117bf5a123184bed05d74eee54657d",
-      "note": "Revision of \"Jerry Robinson\" as of 2021-05-28T21:26:15Z, before generative models."
+      "note": "Revision of \"Jerry Robinson\" as of 2021-05-28T21:26:15Z, before 2022."
     },
     {
       "id": "wp-en-1025797006",
@@ -3181,7 +3181,7 @@
       "doi": null,
       "file": "wp-en-1025797006.txt",
       "sha256": "7b661474790d295eec1a9e93a5b96c063c69574106fb1ba1831251b746afd988",
-      "note": "Revision of \"Emerson, Lake & Palmer (album)\" as of 2021-05-29T16:39:44Z, before generative models."
+      "note": "Revision of \"Emerson, Lake & Palmer (album)\" as of 2021-05-29T16:39:44Z, before 2022."
     },
     {
       "id": "wp-en-1025914326",
@@ -3193,7 +3193,7 @@
       "doi": null,
       "file": "wp-en-1025914326.txt",
       "sha256": "07e12f3dc8aa3f30f8ea7d76571a5d68c27062a841f796d16811d30fdaa63fed",
-      "note": "Revision of \"Montenegrin Volleyball League\" as of 2021-05-30T09:28:13Z, before generative models."
+      "note": "Revision of \"Montenegrin Volleyball League\" as of 2021-05-30T09:28:13Z, before 2022."
     },
     {
       "id": "wp-en-961252368",
@@ -3205,7 +3205,7 @@
       "doi": null,
       "file": "wp-en-961252368.txt",
       "sha256": "3f1b0541e3ed0673c52dd7c65df7f7d927e1591bcda2ccd33e9a5deaffe6bf8a",
-      "note": "Revision of \"The House Behind the Cedars (book)\" as of 2020-06-07T12:21:38Z, before generative models."
+      "note": "Revision of \"The House Behind the Cedars (book)\" as of 2020-06-07T12:21:38Z, before 2022."
     },
     {
       "id": "wp-en-991942346",
@@ -3217,7 +3217,7 @@
       "doi": null,
       "file": "wp-en-991942346.txt",
       "sha256": "1083cc16b1be158087d1dedda6ba603f253a0ddab0227596d82a6915441f182a",
-      "note": "Revision of \"North Star (1996 film)\" as of 2020-12-02T17:13:13Z, before generative models."
+      "note": "Revision of \"North Star (1996 film)\" as of 2020-12-02T17:13:13Z, before 2022."
     },
     {
       "id": "wp-en-995932301",
@@ -3229,7 +3229,7 @@
       "doi": null,
       "file": "wp-en-995932301.txt",
       "sha256": "73efca17d609313df05ec2fbb778a11f71132faa40e93a43848368dd22414a08",
-      "note": "Revision of \"Mick Harvey (umpire)\" as of 2020-12-23T17:18:56Z, before generative models."
+      "note": "Revision of \"Mick Harvey (umpire)\" as of 2020-12-23T17:18:56Z, before 2022."
     },
     {
       "id": "wp-en-995973289",
@@ -3241,7 +3241,7 @@
       "doi": null,
       "file": "wp-en-995973289.txt",
       "sha256": "3a3db60261fc23516600a90ac163d57d17ea633315ec7477616f5f0cf1a5be71",
-      "note": "Revision of \"Wolves as pets and working animals\" as of 2020-12-23T21:25:05Z, before generative models."
+      "note": "Revision of \"Wolves as pets and working animals\" as of 2020-12-23T21:25:05Z, before 2022."
     },
     {
       "id": "wp-en-999222770",
@@ -3253,7 +3253,7 @@
       "doi": null,
       "file": "wp-en-999222770.txt",
       "sha256": "24e0ab979f8128ee2484ecc78ca154adfb9294d2ea697c9647a1c782cbfee43c",
-      "note": "Revision of \"Des Moines City Hall\" as of 2021-01-09T02:34:19Z, before generative models."
+      "note": "Revision of \"Des Moines City Hall\" as of 2021-01-09T02:34:19Z, before 2022."
     },
     {
       "id": "wp-es-117484960",
@@ -3265,7 +3265,7 @@
       "doi": null,
       "file": "wp-es-117484960.txt",
       "sha256": "edde0e13d7a3b9107ca3673956afa32c69f3ad74629641171781450daa4de5f0",
-      "note": "Revision of \"Sociedad Internacional Gutenberg\" as of 2019-07-17T16:43:38Z, before generative models."
+      "note": "Revision of \"Sociedad Internacional Gutenberg\" as of 2019-07-17T16:43:38Z, before 2022."
     },
     {
       "id": "wp-es-117673270",
@@ -3277,7 +3277,7 @@
       "doi": null,
       "file": "wp-es-117673270.txt",
       "sha256": "45f662778ea36ebb44a25d0af177db6f790d9987227aed81e4f735bab5fa920c",
-      "note": "Revision of \"The Fumbler Dwarf\" as of 2019-07-24T19:46:00Z, before generative models."
+      "note": "Revision of \"The Fumbler Dwarf\" as of 2019-07-24T19:46:00Z, before 2022."
     },
     {
       "id": "wp-es-122876621",
@@ -3289,7 +3289,7 @@
       "doi": null,
       "file": "wp-es-122876621.txt",
       "sha256": "0dd7a51debf3079a09b5cbd8a60ccb14904c400ddb2061c6b62fa331c5e89620",
-      "note": "Revision of \"Buey Arriba\" as of 2020-01-19T00:13:10Z, before generative models."
+      "note": "Revision of \"Buey Arriba\" as of 2020-01-19T00:13:10Z, before 2022."
     },
     {
       "id": "wp-es-124179402",
@@ -3301,7 +3301,7 @@
       "doi": null,
       "file": "wp-es-124179402.txt",
       "sha256": "6e0491c9e3a68f89f996b266c7b350ada784e211faef565aea89233b871fdac5",
-      "note": "Revision of \"El despertar de la conciencia\" as of 2020-03-11T11:46:43Z, before generative models."
+      "note": "Revision of \"El despertar de la conciencia\" as of 2020-03-11T11:46:43Z, before 2022."
     },
     {
       "id": "wp-es-127727696",
@@ -3313,7 +3313,7 @@
       "doi": null,
       "file": "wp-es-127727696.txt",
       "sha256": "037f9be999afdb3aeeb677ed9235a2948282f9e4272c95ebfb63f7124b390f54",
-      "note": "Revision of \"Hermann Grassmann\" as of 2020-07-14T19:44:54Z, before generative models."
+      "note": "Revision of \"Hermann Grassmann\" as of 2020-07-14T19:44:54Z, before 2022."
     },
     {
       "id": "wp-es-128084156",
@@ -3325,7 +3325,7 @@
       "doi": null,
       "file": "wp-es-128084156.txt",
       "sha256": "48e9ff9f150fe3eb22d9a2568bf58e9d6c2334d7ace53feeb4309f8e23bb15fb",
-      "note": "Revision of \"Papallacta\" as of 2020-07-28T21:45:11Z, before generative models."
+      "note": "Revision of \"Papallacta\" as of 2020-07-28T21:45:11Z, before 2022."
     },
     {
       "id": "wp-es-130648755",
@@ -3337,7 +3337,7 @@
       "doi": null,
       "file": "wp-es-130648755.txt",
       "sha256": "0206396de310bd45d3ddf0b0990790c6aeecb36b06dd61e83defe915f6f49cdd",
-      "note": "Revision of \"Villa Farnesina\" as of 2020-11-04T19:05:22Z, before generative models."
+      "note": "Revision of \"Villa Farnesina\" as of 2020-11-04T19:05:22Z, before 2022."
     },
     {
       "id": "wp-es-130744068",
@@ -3349,7 +3349,7 @@
       "doi": null,
       "file": "wp-es-130744068.txt",
       "sha256": "6ee0819d1924c56391d83d2ef926b7ef78221bd819b72bfeaf92659e70c4112e",
-      "note": "Revision of \"Marta Kubišová\" as of 2020-11-08T03:59:40Z, before generative models."
+      "note": "Revision of \"Marta Kubišová\" as of 2020-11-08T03:59:40Z, before 2022."
     },
     {
       "id": "wp-es-132061884",
@@ -3361,7 +3361,7 @@
       "doi": null,
       "file": "wp-es-132061884.txt",
       "sha256": "8d545a95366f160ca2fce8ab7cbbbd1faeb929593bda5df50fa0bf177916981c",
-      "note": "Revision of \"Ego el Planeta Viviente\" as of 2020-12-31T02:37:03Z, before generative models."
+      "note": "Revision of \"Ego el Planeta Viviente\" as of 2020-12-31T02:37:03Z, before 2022."
     },
     {
       "id": "wp-es-132146383",
@@ -3373,7 +3373,7 @@
       "doi": null,
       "file": "wp-es-132146383.txt",
       "sha256": "c12f6f85471114cf4afb3dcbc16171fb3fd8b4121528bc891bd3b808efb434f5",
-      "note": "Revision of \"Trescientos millones\" as of 2021-01-04T07:18:03Z, before generative models."
+      "note": "Revision of \"Trescientos millones\" as of 2021-01-04T07:18:03Z, before 2022."
     },
     {
       "id": "wp-es-132719628",
@@ -3385,7 +3385,7 @@
       "doi": null,
       "file": "wp-es-132719628.txt",
       "sha256": "69bc61dfff30ca9723b892f3f16ccfacfc5c0c1068bd4b9249dbb0884e3ccc93",
-      "note": "Revision of \"Türk Mukavemet Teşkilatı\" as of 2021-01-26T20:05:16Z, before generative models."
+      "note": "Revision of \"Türk Mukavemet Teşkilatı\" as of 2021-01-26T20:05:16Z, before 2022."
     },
     {
       "id": "wp-es-132729236",
@@ -3397,7 +3397,7 @@
       "doi": null,
       "file": "wp-es-132729236.txt",
       "sha256": "e1c10ace20fd9db70e4a6390c63b0347e32063c77fd95d7a0ae7c7003672e6d9",
-      "note": "Revision of \"Angiogénesis\" as of 2021-01-27T03:27:32Z, before generative models."
+      "note": "Revision of \"Angiogénesis\" as of 2021-01-27T03:27:32Z, before 2022."
     },
     {
       "id": "wp-es-132743897",
@@ -3409,7 +3409,7 @@
       "doi": null,
       "file": "wp-es-132743897.txt",
       "sha256": "5f63069932cfe9a2d335008f7e6808e718619702875171c5b2231b6e41f7c9ef",
-      "note": "Revision of \"Nava de Campaña\" as of 2021-01-27T18:15:12Z, before generative models."
+      "note": "Revision of \"Nava de Campaña\" as of 2021-01-27T18:15:12Z, before 2022."
     },
     {
       "id": "wp-es-132851509",
@@ -3421,7 +3421,7 @@
       "doi": null,
       "file": "wp-es-132851509.txt",
       "sha256": "c10ca25ddc1474eb1fb6659ec857c005e210cc5fabeee9b06d6e69d06136d15b",
-      "note": "Revision of \"Ua Briain\" as of 2021-01-31T21:56:10Z, before generative models."
+      "note": "Revision of \"Ua Briain\" as of 2021-01-31T21:56:10Z, before 2022."
     },
     {
       "id": "wp-es-133348904",
@@ -3433,7 +3433,7 @@
       "doi": null,
       "file": "wp-es-133348904.txt",
       "sha256": "bfc426384960732ca3d0fdfba15add051501efa48a3dfcbcf7c5822795bc3659",
-      "note": "Revision of \"Cosmopolita sin raíces\" as of 2021-02-19T09:01:17Z, before generative models."
+      "note": "Revision of \"Cosmopolita sin raíces\" as of 2021-02-19T09:01:17Z, before 2022."
     },
     {
       "id": "wp-es-134284862",
@@ -3445,7 +3445,7 @@
       "doi": null,
       "file": "wp-es-134284862.txt",
       "sha256": "45896c61014d5b8e3ce2b3ac42476288c77de4ee1509a53dd1454e2a65ed1975",
-      "note": "Revision of \"15 Big Ones\" as of 2021-03-26T11:27:12Z, before generative models."
+      "note": "Revision of \"15 Big Ones\" as of 2021-03-26T11:27:12Z, before 2022."
     },
     {
       "id": "wp-es-134286913",
@@ -3457,7 +3457,7 @@
       "doi": null,
       "file": "wp-es-134286913.txt",
       "sha256": "13957a5e0c999ff852ee3aa9ed67d2d807c6713cbe51c8e2c8bab758c7537273",
-      "note": "Revision of \"Derechos fundamentales en la Constitución española\" as of 2021-03-26T13:35:19Z, before generative models."
+      "note": "Revision of \"Derechos fundamentales en la Constitución española\" as of 2021-03-26T13:35:19Z, before 2022."
     },
     {
       "id": "wp-es-134393696",
@@ -3469,7 +3469,7 @@
       "doi": null,
       "file": "wp-es-134393696.txt",
       "sha256": "c029e76c902c423f2e23dbe20f8aaf1d10c5fb3cafc5b05ded5492dfb624f933",
-      "note": "Revision of \"Brenda Navarro\" as of 2021-03-30T16:05:42Z, before generative models."
+      "note": "Revision of \"Brenda Navarro\" as of 2021-03-30T16:05:42Z, before 2022."
     },
     {
       "id": "wp-es-134553728",
@@ -3481,7 +3481,7 @@
       "doi": null,
       "file": "wp-es-134553728.txt",
       "sha256": "2a7f197a2357ff31e4eca13da0c512a0491d3237fef259898053abd0fda0cde9",
-      "note": "Revision of \"One Last Breath (canción de Creed)\" as of 2021-04-06T03:52:36Z, before generative models."
+      "note": "Revision of \"One Last Breath (canción de Creed)\" as of 2021-04-06T03:52:36Z, before 2022."
     },
     {
       "id": "wp-es-135297216",
@@ -3493,7 +3493,7 @@
       "doi": null,
       "file": "wp-es-135297216.txt",
       "sha256": "44635a1209db35dddd0f5b35369e3905e816cab5063b1e3e65a10aa78d9f22be",
-      "note": "Revision of \"Beastie Boys\" as of 2021-05-04T19:08:00Z, before generative models."
+      "note": "Revision of \"Beastie Boys\" as of 2021-05-04T19:08:00Z, before 2022."
     },
     {
       "id": "wp-es-135495242",
@@ -3505,7 +3505,7 @@
       "doi": null,
       "file": "wp-es-135495242.txt",
       "sha256": "c386afc56213d4107ea06d35552f51638c95497cdb2787ce494eb3c0bb352ea0",
-      "note": "Revision of \"Maquillaje artístico\" as of 2021-05-12T21:29:36Z, before generative models."
+      "note": "Revision of \"Maquillaje artístico\" as of 2021-05-12T21:29:36Z, before 2022."
     },
     {
       "id": "wp-es-135646104",
@@ -3517,7 +3517,7 @@
       "doi": null,
       "file": "wp-es-135646104.txt",
       "sha256": "abfa414201d6329bf47f9fede084f6a3ccdd3575ae4a6353567a577a40c9c5e6",
-      "note": "Revision of \"Sundome\" as of 2021-05-18T23:49:07Z, before generative models."
+      "note": "Revision of \"Sundome\" as of 2021-05-18T23:49:07Z, before 2022."
     },
     {
       "id": "wp-es-135764642",
@@ -3529,7 +3529,7 @@
       "doi": null,
       "file": "wp-es-135764642.txt",
       "sha256": "57152ac662dc43b4c9e71dd5fcce2acd53fe1a0a4d10cb7763ab7504b10a20ac",
-      "note": "Revision of \"Ancho ibérico\" as of 2021-05-23T17:05:50Z, before generative models."
+      "note": "Revision of \"Ancho ibérico\" as of 2021-05-23T17:05:50Z, before 2022."
     },
     {
       "id": "wp-es-135854886",
@@ -3541,7 +3541,7 @@
       "doi": null,
       "file": "wp-es-135854886.txt",
       "sha256": "6fd5dd654ae329114b18faaa24960dfca3cb93e6eb476394a744624fbb7011f6",
-      "note": "Revision of \"Edad de Oro de la ciencia ficción\" as of 2021-05-26T21:31:15Z, before generative models."
+      "note": "Revision of \"Edad de Oro de la ciencia ficción\" as of 2021-05-26T21:31:15Z, before 2022."
     },
     {
       "id": "wp-es-135862639",
@@ -3553,7 +3553,7 @@
       "doi": null,
       "file": "wp-es-135862639.txt",
       "sha256": "a3a7cab5ea32a79d817fa32d860a3a1816d388bdc9e553ac17fc2359434ba500",
-      "note": "Revision of \"Oligopolio\" as of 2021-05-27T03:52:20Z, before generative models."
+      "note": "Revision of \"Oligopolio\" as of 2021-05-27T03:52:20Z, before 2022."
     }
   ]
 }

--- a/Docs/PARAPHRASE.md
+++ b/Docs/PARAPHRASE.md
@@ -16,7 +16,7 @@ This page measures what such a rewrite does to a passage, using passages whose a
 - **Pair fingerprint** `9fb9e9798f5b2a78`
 - **Run** 2026-08-19
 
-Every human half was published before generative models existed, which is the whole basis for calling it human and the same basis the calibration page rests on. Both halves are the same passage at roughly the same length, so the comparison is within a text rather than between two populations: no collection of machine-written prose was assembled, and none was needed. The pairs are cut from the **opening** of each document, which matters and is measured under Length.
+Every human half was published before 2022, which is the whole basis for calling it human and the same basis the calibration page rests on. Both halves are the same passage at roughly the same length, so the comparison is within a text rather than between two populations: no collection of machine-written prose was assembled, and none was needed. The pairs are cut from the **opening** of each document, which matters and is measured under Length.
 
 **This half of the study ages, and the human half does not.** A 2019 paper will still have been written in 2019 a decade from now; the rewrite is the work of one model on one day. That is why the model and the date are printed above rather than buried, and why the right response to "but a newer model rewrites differently" is to re-run this with that model rather than to argue about it.
 

--- a/src/SignsOfAI.Core/Calibration/PublishedCalibration.cs
+++ b/src/SignsOfAI.Core/Calibration/PublishedCalibration.cs
@@ -22,7 +22,7 @@ public sealed record PublishedCalibration
     /// <summary>The corpus this was measured against, e.g. "signsofai-human-baseline".</summary>
     public required string CorpusId { get; init; }
 
-    /// <summary>How many texts, all published before generative models could have written them.</summary>
+    /// <summary>How many texts, all written before 2022, so no generative model could have written them.</summary>
     public required int Texts { get; init; }
 
     /// <summary>Date of the measuring run, yyyy-MM-dd.</summary>

--- a/src/SignsOfAI.Core/Model/AnalysisResult.cs
+++ b/src/SignsOfAI.Core/Model/AnalysisResult.cs
@@ -50,7 +50,7 @@ public sealed record AnalysisResult
 
     /// <summary>
     /// What matched but is not evidence: rules this text uses at a rate measured on writing published
-    /// before generative models existed. Worth showing — "you use 'furthermore' about as often as
+    /// written before 2022. Worth showing — "you use 'furthermore' about as often as
     /// other people do" is a useful thing to be told — and worth nothing to the score.
     /// </summary>
     public IReadOnlyList<Finding> Observations => field ??= [.. Findings.Where(f => f.AtHumanRate)];

--- a/src/SignsOfAI.Core/Model/Finding.cs
+++ b/src/SignsOfAI.Core/Model/Finding.cs
@@ -45,7 +45,7 @@ public sealed record Finding
 
     /// <summary>
     /// True when this rule is being used in this text at a rate people write at, measured against
-    /// writing published before generative models existed. The finding still describes something real
+    /// writing published before 2022. The finding still describes something real
     /// and is still shown, but it is not evidence of a machine and contributes nothing to the score.
     ///
     /// It is marked rather than removed on purpose. Ninety human academic papers produced a median of

--- a/src/SignsOfAI.Core/Rules/GenreGate.cs
+++ b/src/SignsOfAI.Core/Rules/GenreGate.cs
@@ -5,7 +5,7 @@ namespace SignsOfAI.Core.Rules;
 /// <summary>
 /// Marks the findings of rules that are describing the genre rather than the machine.
 ///
-/// Measuring the analyzer against ninety texts published before generative models existed produced a
+/// Measuring the analyzer against the calibration corpus, all of it written before 2022, produced a
 /// number worth staring at: a median of <b>seven</b> flagged tells per human academic paper, 888
 /// across the corpus, with only two of the ninety coming back clean. The score survived that — the
 /// median was 6.8 out of 100 and nothing reached the recommended threshold — because the rules

--- a/src/SignsOfAI.Mcp/Tools/ReportTools.cs
+++ b/src/SignsOfAI.Mcp/Tools/ReportTools.cs
@@ -31,7 +31,7 @@ public static class ReportTools
         disagree with its own bibliography. Checkable facts are named at the top and kept apart from the score,
         which is an opinion about prose.
         Every report prints how often this build is wrong, measured for the language actually analysed against
-        texts published before generative models existed, and names the rules known to fire on human writing so
+        texts written before 2022, and names the rules known to fire on human writing so
         the reader can weigh evidence that leans on one. Below the threshold that measurement supports, no
         verdict is given at all.
         Runs FULLY OFFLINE. The result contains material from the document, so treat it as you would the

--- a/src/SignsOfAI.Web/wwwroot/why.html
+++ b/src/SignsOfAI.Web/wwwroot/why.html
@@ -14,18 +14,23 @@
   server — and the same defect we shipped in the report this month (an image tag that fetched a
   pixel when a teacher pasted it into a comment box) is exactly what this rule prevents here.
 
-  The numbers are drawn, not tabulated. "Zero of ninety, with a 95% interval reaching 4.1%" is a
-  sentence a statistician reads and everybody else skips. Ninety dots with none of them filled is a
-  picture anyone reads in a second, and the interval drawn around the zero is why we do not claim
-  zero.
+  The numbers are drawn, not tabulated. "Two of 296, with a 95% interval reaching 2.4%" is a
+  sentence a statistician reads and everybody else skips. Two hundred and ninety-six dots with two
+  of them filled is a picture anyone reads in a second, and the interval drawn around them is why
+  the rate is a range and not a promise.
 
   Both languages live in this file, switched with a radio input and :has() — no script at all. The
   Spanish is written in Spanish rather than translated into it, as everything else here is.
 
   Every figure comes from src/SignsOfAI.Core/Calibration/published-calibration.json, measured on
-  2026-08-05 with engine 0.4.0. If that file changes, this page is stale and must be regenerated
+  2026-09-07 with engine 0.7.0. If that file changes, this page is stale and must be regenerated
   by hand — there is no build step behind it, deliberately: it has to open from a downloads folder
   years from now on a machine that has never heard of this project.
+
+  Saying that in a comment was not enough. It sat here from 5 August while the corpus grew from
+  ninety texts to 296 and the published rate stopped being zero, and this page — the one the README
+  sends teachers to first — went on showing a green zero for six days. WhyPageTests now fails when
+  the calibration moves and these figures do not, so the next person is told instead of trusted.
 -->
 <html lang="es">
 <head>
@@ -180,60 +185,65 @@ body:has(#en:checked) .only-en{display:block}
   una persona delante.
 </p>
 <p>
-  Lo medimos así: noventa textos <strong>publicados antes de que existieran los modelos
-  generativos</strong>. No los juzgó nadie: sabemos que son humanos por su fecha. Después los
-  pasamos por la herramienta y contamos a cuántos habría acusado.
+  Lo medimos así: <strong>296 textos escritos antes de 2022</strong> — artículos publicados,
+  revisiones de Wikipedia y ensayos de clase. No los juzgó nadie: sabemos que son humanos por su
+  fecha. Después los pasamos por la herramienta y contamos a cuántos habría acusado.
 </p>
 
 <figure>
-  <svg viewBox="0 0 640 250" role="img" aria-label="Noventa círculos, ninguno marcado, y el intervalo dibujado alrededor del cero">
-    <text x="0" y="14" fill="currentColor" font-size="13" font-weight="700" opacity=".75">90 TEXTOS HUMANOS</text>
+  <svg viewBox="0 0 640 250" role="img" aria-label="Doscientos noventa y seis círculos, dos de ellos marcados, y el intervalo dibujado alrededor de la cifra medida">
+    <text x="0" y="14" fill="currentColor" font-size="13" font-weight="700" opacity=".75">296 TEXTOS HUMANOS</text>
     <g fill="none" stroke="currentColor" stroke-opacity=".38" stroke-width="1.5">
       <!-- 90 dots: 15 per row, 6 rows. None filled, because none was flagged. -->
-      <circle cx="12" cy="38" r="6"/><circle cx="36" cy="38" r="6"/><circle cx="60" cy="38" r="6"/><circle cx="84" cy="38" r="6"/><circle cx="108" cy="38" r="6"/><circle cx="132" cy="38" r="6"/><circle cx="156" cy="38" r="6"/><circle cx="180" cy="38" r="6"/><circle cx="204" cy="38" r="6"/><circle cx="228" cy="38" r="6"/><circle cx="252" cy="38" r="6"/><circle cx="276" cy="38" r="6"/><circle cx="300" cy="38" r="6"/><circle cx="324" cy="38" r="6"/><circle cx="348" cy="38" r="6"/>
-      <circle cx="12" cy="62" r="6"/><circle cx="36" cy="62" r="6"/><circle cx="60" cy="62" r="6"/><circle cx="84" cy="62" r="6"/><circle cx="108" cy="62" r="6"/><circle cx="132" cy="62" r="6"/><circle cx="156" cy="62" r="6"/><circle cx="180" cy="62" r="6"/><circle cx="204" cy="62" r="6"/><circle cx="228" cy="62" r="6"/><circle cx="252" cy="62" r="6"/><circle cx="276" cy="62" r="6"/><circle cx="300" cy="62" r="6"/><circle cx="324" cy="62" r="6"/><circle cx="348" cy="62" r="6"/>
-      <circle cx="12" cy="86" r="6"/><circle cx="36" cy="86" r="6"/><circle cx="60" cy="86" r="6"/><circle cx="84" cy="86" r="6"/><circle cx="108" cy="86" r="6"/><circle cx="132" cy="86" r="6"/><circle cx="156" cy="86" r="6"/><circle cx="180" cy="86" r="6"/><circle cx="204" cy="86" r="6"/><circle cx="228" cy="86" r="6"/><circle cx="252" cy="86" r="6"/><circle cx="276" cy="86" r="6"/><circle cx="300" cy="86" r="6"/><circle cx="324" cy="86" r="6"/><circle cx="348" cy="86" r="6"/>
-      <circle cx="12" cy="110" r="6"/><circle cx="36" cy="110" r="6"/><circle cx="60" cy="110" r="6"/><circle cx="84" cy="110" r="6"/><circle cx="108" cy="110" r="6"/><circle cx="132" cy="110" r="6"/><circle cx="156" cy="110" r="6"/><circle cx="180" cy="110" r="6"/><circle cx="204" cy="110" r="6"/><circle cx="228" cy="110" r="6"/><circle cx="252" cy="110" r="6"/><circle cx="276" cy="110" r="6"/><circle cx="300" cy="110" r="6"/><circle cx="324" cy="110" r="6"/><circle cx="348" cy="110" r="6"/>
-      <circle cx="12" cy="134" r="6"/><circle cx="36" cy="134" r="6"/><circle cx="60" cy="134" r="6"/><circle cx="84" cy="134" r="6"/><circle cx="108" cy="134" r="6"/><circle cx="132" cy="134" r="6"/><circle cx="156" cy="134" r="6"/><circle cx="180" cy="134" r="6"/><circle cx="204" cy="134" r="6"/><circle cx="228" cy="134" r="6"/><circle cx="252" cy="134" r="6"/><circle cx="276" cy="134" r="6"/><circle cx="300" cy="134" r="6"/><circle cx="324" cy="134" r="6"/><circle cx="348" cy="134" r="6"/>
-      <circle cx="12" cy="158" r="6"/><circle cx="36" cy="158" r="6"/><circle cx="60" cy="158" r="6"/><circle cx="84" cy="158" r="6"/><circle cx="108" cy="158" r="6"/><circle cx="132" cy="158" r="6"/><circle cx="156" cy="158" r="6"/><circle cx="180" cy="158" r="6"/><circle cx="204" cy="158" r="6"/><circle cx="228" cy="158" r="6"/><circle cx="252" cy="158" r="6"/><circle cx="276" cy="158" r="6"/><circle cx="300" cy="158" r="6"/><circle cx="324" cy="158" r="6"/><circle cx="348" cy="158" r="6"/>
+      <circle cx="12" cy="34" r="3.2"/><circle cx="23" cy="34" r="3.2"/><circle cx="34" cy="34" r="3.2"/><circle cx="45" cy="34" r="3.2"/><circle cx="56" cy="34" r="3.2"/><circle cx="67" cy="34" r="3.2"/><circle cx="78" cy="34" r="3.2"/><circle cx="89" cy="34" r="3.2"/><circle cx="100" cy="34" r="3.2"/><circle cx="111" cy="34" r="3.2"/><circle cx="122" cy="34" r="3.2"/><circle cx="133" cy="34" r="3.2"/><circle cx="144" cy="34" r="3.2"/><circle cx="155" cy="34" r="3.2"/><circle cx="166" cy="34" r="3.2"/><circle cx="177" cy="34" r="3.2"/><circle cx="188" cy="34" r="3.2"/><circle cx="199" cy="34" r="3.2"/><circle cx="210" cy="34" r="3.2"/><circle cx="221" cy="34" r="3.2"/><circle cx="232" cy="34" r="3.2"/><circle cx="243" cy="34" r="3.2"/><circle cx="254" cy="34" r="3.2"/><circle cx="265" cy="34" r="3.2"/><circle cx="276" cy="34" r="3.2"/><circle cx="287" cy="34" r="3.2"/><circle cx="298" cy="34" r="3.2"/><circle cx="309" cy="34" r="3.2"/><circle cx="320" cy="34" r="3.2"/><circle cx="331" cy="34" r="3.2"/><circle cx="342" cy="34" r="3.2"/><circle cx="353" cy="34" r="3.2"/><circle cx="364" cy="34" r="3.2"/><circle cx="375" cy="34" r="3.2"/><circle cx="386" cy="34" r="3.2"/><circle cx="397" cy="34" r="3.2"/><circle cx="408" cy="34" r="3.2"/>
+      <circle cx="12" cy="47" r="3.2"/><circle cx="23" cy="47" r="3.2"/><circle cx="34" cy="47" r="3.2"/><circle cx="45" cy="47" r="3.2"/><circle cx="56" cy="47" r="3.2"/><circle cx="67" cy="47" r="3.2"/><circle cx="78" cy="47" r="3.2"/><circle cx="89" cy="47" r="3.2"/><circle cx="100" cy="47" r="3.2"/><circle cx="111" cy="47" r="3.2"/><circle cx="122" cy="47" r="3.2"/><circle cx="133" cy="47" r="3.2"/><circle cx="144" cy="47" r="3.2"/><circle cx="155" cy="47" r="3.2"/><circle cx="166" cy="47" r="3.2"/><circle cx="177" cy="47" r="3.2"/><circle cx="188" cy="47" r="3.2"/><circle cx="199" cy="47" r="3.2"/><circle cx="210" cy="47" r="3.2"/><circle cx="221" cy="47" r="3.2"/><circle cx="232" cy="47" r="3.2"/><circle cx="243" cy="47" r="3.2"/><circle cx="254" cy="47" r="3.2"/><circle cx="265" cy="47" r="3.2"/><circle cx="276" cy="47" r="3.2"/><circle cx="287" cy="47" r="3.2"/><circle cx="298" cy="47" r="3.2"/><circle cx="309" cy="47" r="3.2"/><circle cx="320" cy="47" r="3.2"/><circle cx="331" cy="47" r="3.2"/><circle cx="342" cy="47" r="3.2"/><circle cx="353" cy="47" r="3.2"/><circle cx="364" cy="47" r="3.2"/><circle cx="375" cy="47" r="3.2" fill="#f59e0b" stroke="#f59e0b"/><circle cx="386" cy="47" r="3.2"/><circle cx="397" cy="47" r="3.2"/><circle cx="408" cy="47" r="3.2"/>
+      <circle cx="12" cy="60" r="3.2"/><circle cx="23" cy="60" r="3.2"/><circle cx="34" cy="60" r="3.2"/><circle cx="45" cy="60" r="3.2"/><circle cx="56" cy="60" r="3.2"/><circle cx="67" cy="60" r="3.2"/><circle cx="78" cy="60" r="3.2"/><circle cx="89" cy="60" r="3.2"/><circle cx="100" cy="60" r="3.2"/><circle cx="111" cy="60" r="3.2"/><circle cx="122" cy="60" r="3.2"/><circle cx="133" cy="60" r="3.2"/><circle cx="144" cy="60" r="3.2"/><circle cx="155" cy="60" r="3.2"/><circle cx="166" cy="60" r="3.2"/><circle cx="177" cy="60" r="3.2"/><circle cx="188" cy="60" r="3.2"/><circle cx="199" cy="60" r="3.2"/><circle cx="210" cy="60" r="3.2"/><circle cx="221" cy="60" r="3.2"/><circle cx="232" cy="60" r="3.2"/><circle cx="243" cy="60" r="3.2"/><circle cx="254" cy="60" r="3.2"/><circle cx="265" cy="60" r="3.2"/><circle cx="276" cy="60" r="3.2"/><circle cx="287" cy="60" r="3.2"/><circle cx="298" cy="60" r="3.2"/><circle cx="309" cy="60" r="3.2"/><circle cx="320" cy="60" r="3.2"/><circle cx="331" cy="60" r="3.2"/><circle cx="342" cy="60" r="3.2"/><circle cx="353" cy="60" r="3.2"/><circle cx="364" cy="60" r="3.2"/><circle cx="375" cy="60" r="3.2"/><circle cx="386" cy="60" r="3.2"/><circle cx="397" cy="60" r="3.2"/><circle cx="408" cy="60" r="3.2"/>
+      <circle cx="12" cy="73" r="3.2"/><circle cx="23" cy="73" r="3.2"/><circle cx="34" cy="73" r="3.2"/><circle cx="45" cy="73" r="3.2"/><circle cx="56" cy="73" r="3.2"/><circle cx="67" cy="73" r="3.2"/><circle cx="78" cy="73" r="3.2"/><circle cx="89" cy="73" r="3.2"/><circle cx="100" cy="73" r="3.2"/><circle cx="111" cy="73" r="3.2"/><circle cx="122" cy="73" r="3.2"/><circle cx="133" cy="73" r="3.2"/><circle cx="144" cy="73" r="3.2"/><circle cx="155" cy="73" r="3.2"/><circle cx="166" cy="73" r="3.2"/><circle cx="177" cy="73" r="3.2"/><circle cx="188" cy="73" r="3.2"/><circle cx="199" cy="73" r="3.2"/><circle cx="210" cy="73" r="3.2"/><circle cx="221" cy="73" r="3.2"/><circle cx="232" cy="73" r="3.2"/><circle cx="243" cy="73" r="3.2"/><circle cx="254" cy="73" r="3.2"/><circle cx="265" cy="73" r="3.2"/><circle cx="276" cy="73" r="3.2"/><circle cx="287" cy="73" r="3.2"/><circle cx="298" cy="73" r="3.2"/><circle cx="309" cy="73" r="3.2"/><circle cx="320" cy="73" r="3.2"/><circle cx="331" cy="73" r="3.2"/><circle cx="342" cy="73" r="3.2"/><circle cx="353" cy="73" r="3.2"/><circle cx="364" cy="73" r="3.2"/><circle cx="375" cy="73" r="3.2"/><circle cx="386" cy="73" r="3.2"/><circle cx="397" cy="73" r="3.2"/><circle cx="408" cy="73" r="3.2"/>
+      <circle cx="12" cy="86" r="3.2"/><circle cx="23" cy="86" r="3.2"/><circle cx="34" cy="86" r="3.2"/><circle cx="45" cy="86" r="3.2"/><circle cx="56" cy="86" r="3.2"/><circle cx="67" cy="86" r="3.2"/><circle cx="78" cy="86" r="3.2"/><circle cx="89" cy="86" r="3.2"/><circle cx="100" cy="86" r="3.2"/><circle cx="111" cy="86" r="3.2"/><circle cx="122" cy="86" r="3.2"/><circle cx="133" cy="86" r="3.2"/><circle cx="144" cy="86" r="3.2"/><circle cx="155" cy="86" r="3.2"/><circle cx="166" cy="86" r="3.2"/><circle cx="177" cy="86" r="3.2"/><circle cx="188" cy="86" r="3.2"/><circle cx="199" cy="86" r="3.2"/><circle cx="210" cy="86" r="3.2"/><circle cx="221" cy="86" r="3.2"/><circle cx="232" cy="86" r="3.2"/><circle cx="243" cy="86" r="3.2"/><circle cx="254" cy="86" r="3.2"/><circle cx="265" cy="86" r="3.2"/><circle cx="276" cy="86" r="3.2"/><circle cx="287" cy="86" r="3.2"/><circle cx="298" cy="86" r="3.2"/><circle cx="309" cy="86" r="3.2"/><circle cx="320" cy="86" r="3.2"/><circle cx="331" cy="86" r="3.2"/><circle cx="342" cy="86" r="3.2"/><circle cx="353" cy="86" r="3.2"/><circle cx="364" cy="86" r="3.2"/><circle cx="375" cy="86" r="3.2"/><circle cx="386" cy="86" r="3.2"/><circle cx="397" cy="86" r="3.2"/><circle cx="408" cy="86" r="3.2"/>
+      <circle cx="12" cy="99" r="3.2"/><circle cx="23" cy="99" r="3.2"/><circle cx="34" cy="99" r="3.2"/><circle cx="45" cy="99" r="3.2"/><circle cx="56" cy="99" r="3.2"/><circle cx="67" cy="99" r="3.2" fill="#f59e0b" stroke="#f59e0b"/><circle cx="78" cy="99" r="3.2"/><circle cx="89" cy="99" r="3.2"/><circle cx="100" cy="99" r="3.2"/><circle cx="111" cy="99" r="3.2"/><circle cx="122" cy="99" r="3.2"/><circle cx="133" cy="99" r="3.2"/><circle cx="144" cy="99" r="3.2"/><circle cx="155" cy="99" r="3.2"/><circle cx="166" cy="99" r="3.2"/><circle cx="177" cy="99" r="3.2"/><circle cx="188" cy="99" r="3.2"/><circle cx="199" cy="99" r="3.2"/><circle cx="210" cy="99" r="3.2"/><circle cx="221" cy="99" r="3.2"/><circle cx="232" cy="99" r="3.2"/><circle cx="243" cy="99" r="3.2"/><circle cx="254" cy="99" r="3.2"/><circle cx="265" cy="99" r="3.2"/><circle cx="276" cy="99" r="3.2"/><circle cx="287" cy="99" r="3.2"/><circle cx="298" cy="99" r="3.2"/><circle cx="309" cy="99" r="3.2"/><circle cx="320" cy="99" r="3.2"/><circle cx="331" cy="99" r="3.2"/><circle cx="342" cy="99" r="3.2"/><circle cx="353" cy="99" r="3.2"/><circle cx="364" cy="99" r="3.2"/><circle cx="375" cy="99" r="3.2"/><circle cx="386" cy="99" r="3.2"/><circle cx="397" cy="99" r="3.2"/><circle cx="408" cy="99" r="3.2"/>
+      <circle cx="12" cy="112" r="3.2"/><circle cx="23" cy="112" r="3.2"/><circle cx="34" cy="112" r="3.2"/><circle cx="45" cy="112" r="3.2"/><circle cx="56" cy="112" r="3.2"/><circle cx="67" cy="112" r="3.2"/><circle cx="78" cy="112" r="3.2"/><circle cx="89" cy="112" r="3.2"/><circle cx="100" cy="112" r="3.2"/><circle cx="111" cy="112" r="3.2"/><circle cx="122" cy="112" r="3.2"/><circle cx="133" cy="112" r="3.2"/><circle cx="144" cy="112" r="3.2"/><circle cx="155" cy="112" r="3.2"/><circle cx="166" cy="112" r="3.2"/><circle cx="177" cy="112" r="3.2"/><circle cx="188" cy="112" r="3.2"/><circle cx="199" cy="112" r="3.2"/><circle cx="210" cy="112" r="3.2"/><circle cx="221" cy="112" r="3.2"/><circle cx="232" cy="112" r="3.2"/><circle cx="243" cy="112" r="3.2"/><circle cx="254" cy="112" r="3.2"/><circle cx="265" cy="112" r="3.2"/><circle cx="276" cy="112" r="3.2"/><circle cx="287" cy="112" r="3.2"/><circle cx="298" cy="112" r="3.2"/><circle cx="309" cy="112" r="3.2"/><circle cx="320" cy="112" r="3.2"/><circle cx="331" cy="112" r="3.2"/><circle cx="342" cy="112" r="3.2"/><circle cx="353" cy="112" r="3.2"/><circle cx="364" cy="112" r="3.2"/><circle cx="375" cy="112" r="3.2"/><circle cx="386" cy="112" r="3.2"/><circle cx="397" cy="112" r="3.2"/><circle cx="408" cy="112" r="3.2"/>
+      <circle cx="12" cy="125" r="3.2"/><circle cx="23" cy="125" r="3.2"/><circle cx="34" cy="125" r="3.2"/><circle cx="45" cy="125" r="3.2"/><circle cx="56" cy="125" r="3.2"/><circle cx="67" cy="125" r="3.2"/><circle cx="78" cy="125" r="3.2"/><circle cx="89" cy="125" r="3.2"/><circle cx="100" cy="125" r="3.2"/><circle cx="111" cy="125" r="3.2"/><circle cx="122" cy="125" r="3.2"/><circle cx="133" cy="125" r="3.2"/><circle cx="144" cy="125" r="3.2"/><circle cx="155" cy="125" r="3.2"/><circle cx="166" cy="125" r="3.2"/><circle cx="177" cy="125" r="3.2"/><circle cx="188" cy="125" r="3.2"/><circle cx="199" cy="125" r="3.2"/><circle cx="210" cy="125" r="3.2"/><circle cx="221" cy="125" r="3.2"/><circle cx="232" cy="125" r="3.2"/><circle cx="243" cy="125" r="3.2"/><circle cx="254" cy="125" r="3.2"/><circle cx="265" cy="125" r="3.2"/><circle cx="276" cy="125" r="3.2"/><circle cx="287" cy="125" r="3.2"/><circle cx="298" cy="125" r="3.2"/><circle cx="309" cy="125" r="3.2"/><circle cx="320" cy="125" r="3.2"/><circle cx="331" cy="125" r="3.2"/><circle cx="342" cy="125" r="3.2"/><circle cx="353" cy="125" r="3.2"/><circle cx="364" cy="125" r="3.2"/><circle cx="375" cy="125" r="3.2"/><circle cx="386" cy="125" r="3.2"/><circle cx="397" cy="125" r="3.2"/><circle cx="408" cy="125" r="3.2"/>
     </g>
-    <text x="380" y="86" fill="#2fd27a" font-size="46" font-weight="800">0</text>
-    <text x="380" y="112" fill="currentColor" font-size="14" opacity=".8">marcados</text>
-    <text x="380" y="134" fill="currentColor" font-size="13" opacity=".55">ninguno relleno,</text>
-    <text x="380" y="151" fill="currentColor" font-size="13" opacity=".55">ninguno acusado</text>
+    <text x="442" y="72" fill="#f59e0b" font-size="46" font-weight="800">2</text>
+    <text x="442" y="98" fill="currentColor" font-size="14" opacity=".8">marcados</text>
+    <text x="442" y="120" fill="currentColor" font-size="13" opacity=".55">los dos rellenos,</text>
+    <text x="442" y="137" fill="currentColor" font-size="13" opacity=".55">de doscientos noventa y seis</text>
 
-    <!-- The interval, drawn, because zero of ninety is not a rate of zero. -->
-    <text x="0" y="196" fill="currentColor" font-size="12" font-weight="700" opacity=".75">LO QUE SE PUEDE AFIRMAR DE VERDAD</text>
+    <!-- The interval, drawn, because two of 296 is a range and not a promise. -->
+    <text x="0" y="172" fill="currentColor" font-size="12" font-weight="700" opacity=".75">LO QUE SE PUEDE AFIRMAR DE VERDAD</text>
     <line x1="12" y1="216" x2="620" y2="216" stroke="currentColor" stroke-opacity=".25" stroke-width="2"/>
-    <rect x="12" y="209" width="249" height="14" rx="7" fill="#f59e0b" fill-opacity=".28"/>
-    <circle cx="12" cy="216" r="6" fill="#2fd27a"/>
+    <rect x="24" y="209" width="134" height="14" rx="7" fill="#f59e0b" fill-opacity=".28"/>
+    <circle cx="53" cy="216" r="6" fill="#2fd27a"/>
+    <text x="53" y="202" fill="#2fd27a" font-size="12" font-weight="700" text-anchor="middle">0,7 %</text>
     <text x="12" y="241" fill="currentColor" font-size="12" opacity=".75">0 %</text>
-    <text x="222" y="241" fill="#f59e0b" font-size="12" font-weight="700">4,1 %</text>
+    <text x="168" y="241" fill="#f59e0b" font-size="12" font-weight="700">2,4 %</text>
     <text x="620" y="241" fill="currentColor" font-size="12" opacity=".55" text-anchor="end">10 %</text>
   </svg>
   <figcaption>
-    Ninguno de los noventa fue marcado. Pero <strong>cero de noventa no significa que la tasa
-    sea cero</strong>: con esa muestra, lo máximo que se puede afirmar honestamente es que se
-    equivoca <strong>menos del 4,1 %</strong> de las veces. Esa franja ámbar es la diferencia
-    entre una medición y una promesa.
+    Dos de los 296 fueron marcados: el <strong>0,7 %</strong>. Pero dos de 296 tampoco es
+    exactamente la tasa: con esa muestra, lo máximo que se puede afirmar honestamente es que se
+    equivoca <strong>menos del 2,4 %</strong> de las veces. Esa franja ámbar es la diferencia
+    entre una medición y una promesa. <strong>No es cero, y ese es justamente el punto</strong>:
+    hasta septiembre esta página enseñaba un cero, porque el corpus todavía no contenía a las
+    personas con más probabilidades de ser acusadas en falso.
   </figcaption>
 </figure>
 
 <h3>Y no es el mismo número para todos</h3>
 <p>
   Repartir la cifra global a todo el mundo sería cómodo y sería falso. El corpus tiene
-  sesenta y cinco textos en inglés y veinticinco en español, así que lo que se puede
+  <strong>271 textos en inglés y veinticinco en español</strong>, así que lo que se puede
   afirmar sobre cada idioma es distinto — y en la herramienta cada lector ve el suyo,
   no el promedio.
 </p>
 
 <figure>
-  <svg viewBox="0 0 640 140" role="img" aria-label="Cota por idioma: inglés 5,6 por ciento, español 13,3 por ciento">
+  <svg viewBox="0 0 640 140" role="img" aria-label="Cota por idioma: inglés 2,7 por ciento, español 13,3 por ciento">
     <text x="0" y="22" fill="currentColor" font-size="14" font-weight="600">Inglés</text>
-    <text x="0" y="39" fill="currentColor" font-size="11.5" opacity=".55">65 textos</text>
+    <text x="0" y="39" fill="currentColor" font-size="11.5" opacity=".55">271 textos</text>
     <line x1="120" y1="26" x2="620" y2="26" stroke="currentColor" stroke-opacity=".2" stroke-width="2"/>
-    <rect x="120" y="19" width="187" height="14" rx="7" fill="#f59e0b" fill-opacity=".3"/>
-    <text x="317" y="31" fill="#f59e0b" font-size="13" font-weight="700">5,6 %</text>
+    <rect x="120" y="19" width="90" height="14" rx="7" fill="#f59e0b" fill-opacity=".3"/>
+    <text x="220" y="31" fill="#f59e0b" font-size="13" font-weight="700">2,7 %</text>
 
     <text x="0" y="80" fill="currentColor" font-size="14" font-weight="600">Español</text>
     <text x="0" y="97" fill="currentColor" font-size="11.5" opacity=".55">25 textos</text>
@@ -262,15 +272,24 @@ body:has(#en:checked) .only-en{display:block}
   que estaban de moda ese mes. Una herramienta que no marca nada tiene una tasa de error perfecta.
 </p>
 <p>
-  Los noventa textos son <strong>artículos publicados, no trabajos de estudiantes</strong>. Un
-  ensayo de primero de carrera no se parece a un artículo revisado por pares, y esa diferencia
-  no está medida aquí.
+  <strong>Sí incluye trabajos de estudiantes, y esa es la parte que más le importa a usted.</strong>
+  De los 296 textos, <strong>206 son ensayos de clase</strong> escritos por adultos que estaban
+  aprendiendo inglés. Es exactamente el grupo del que se acusa a los detectores de equivocarse más,
+  y aquí es el que peor sale: mide más alto que cualquier otro grupo en todas las columnas. A un
+  umbral de 25 sobre 100 se marcaban nueve de ellos. <strong>Por eso la frontera está en 30 y no
+  en 25</strong> — se movió cuando supimos a quién estaba haciendo daño.
+</p>
+<p>
+  Lo que sigue sin medirse es el <strong>ensayo de estudiante en español</strong>: los veinticinco
+  textos en español son revisiones de Wikipedia de una sola fuente. Ahí esta herramienta sabe
+  menos, y lo dice en vez de prestarle a un idioma una cifra que midió en otro.
 </p>
 <div class="quote">
-  Y una que conviene saber antes de mirar ninguna puntuación: la señal que más salta en escritura
-  humana es <b>el ritmo uniforme de las frases</b> — aparece en el <b>27,8 %</b> de los textos
-  humanos que medimos. Si la evidencia de un trabajo se apoya sobre todo en eso, vale menos.
-  La herramienta lo dice en cada informe, por su nombre.
+  Y una que conviene saber antes de mirar ninguna puntuación: las señales que más saltan en
+  escritura humana casi no dicen nada. <b>El ritmo uniforme de las frases</b> aparece en el
+  <b>32,1 %</b> de los textos humanos que medimos, y la palabra «just» en el <b>34,8 %</b>. Si la
+  evidencia de un trabajo se apoya sobre todo en eso, vale menos. La herramienta lo dice en cada
+  informe, por su nombre.
 </div>
 
 <h2>¿Por qué fiarse de este y no de otro?</h2>
@@ -375,57 +394,62 @@ body:has(#en:checked) .only-en{display:block}
   on the other side of it.
 </p>
 <p>
-  Here is how it was measured: ninety texts <strong>published before generative models
-  existed</strong>. Nobody judged them human — their dates did. Then they went through the tool and
-  we counted how many it would have accused.
+  Here is how it was measured: <strong>296 texts written before 2022</strong> — published
+  articles, Wikipedia revisions and classroom essays. Nobody judged them human; their dates did.
+  Then they went through the tool and we counted how many it would have accused.
 </p>
 
 <figure>
-  <svg viewBox="0 0 640 250" role="img" aria-label="Ninety circles, none of them filled, and the interval drawn around zero">
-    <text x="0" y="14" fill="currentColor" font-size="13" font-weight="700" opacity=".75">90 HUMAN TEXTS</text>
+  <svg viewBox="0 0 640 250" role="img" aria-label="Two hundred and ninety-six circles, two of them filled, and the interval drawn around the measured figure">
+    <text x="0" y="14" fill="currentColor" font-size="13" font-weight="700" opacity=".75">296 HUMAN TEXTS</text>
     <g fill="none" stroke="currentColor" stroke-opacity=".38" stroke-width="1.5">
-      <circle cx="12" cy="38" r="6"/><circle cx="36" cy="38" r="6"/><circle cx="60" cy="38" r="6"/><circle cx="84" cy="38" r="6"/><circle cx="108" cy="38" r="6"/><circle cx="132" cy="38" r="6"/><circle cx="156" cy="38" r="6"/><circle cx="180" cy="38" r="6"/><circle cx="204" cy="38" r="6"/><circle cx="228" cy="38" r="6"/><circle cx="252" cy="38" r="6"/><circle cx="276" cy="38" r="6"/><circle cx="300" cy="38" r="6"/><circle cx="324" cy="38" r="6"/><circle cx="348" cy="38" r="6"/>
-      <circle cx="12" cy="62" r="6"/><circle cx="36" cy="62" r="6"/><circle cx="60" cy="62" r="6"/><circle cx="84" cy="62" r="6"/><circle cx="108" cy="62" r="6"/><circle cx="132" cy="62" r="6"/><circle cx="156" cy="62" r="6"/><circle cx="180" cy="62" r="6"/><circle cx="204" cy="62" r="6"/><circle cx="228" cy="62" r="6"/><circle cx="252" cy="62" r="6"/><circle cx="276" cy="62" r="6"/><circle cx="300" cy="62" r="6"/><circle cx="324" cy="62" r="6"/><circle cx="348" cy="62" r="6"/>
-      <circle cx="12" cy="86" r="6"/><circle cx="36" cy="86" r="6"/><circle cx="60" cy="86" r="6"/><circle cx="84" cy="86" r="6"/><circle cx="108" cy="86" r="6"/><circle cx="132" cy="86" r="6"/><circle cx="156" cy="86" r="6"/><circle cx="180" cy="86" r="6"/><circle cx="204" cy="86" r="6"/><circle cx="228" cy="86" r="6"/><circle cx="252" cy="86" r="6"/><circle cx="276" cy="86" r="6"/><circle cx="300" cy="86" r="6"/><circle cx="324" cy="86" r="6"/><circle cx="348" cy="86" r="6"/>
-      <circle cx="12" cy="110" r="6"/><circle cx="36" cy="110" r="6"/><circle cx="60" cy="110" r="6"/><circle cx="84" cy="110" r="6"/><circle cx="108" cy="110" r="6"/><circle cx="132" cy="110" r="6"/><circle cx="156" cy="110" r="6"/><circle cx="180" cy="110" r="6"/><circle cx="204" cy="110" r="6"/><circle cx="228" cy="110" r="6"/><circle cx="252" cy="110" r="6"/><circle cx="276" cy="110" r="6"/><circle cx="300" cy="110" r="6"/><circle cx="324" cy="110" r="6"/><circle cx="348" cy="110" r="6"/>
-      <circle cx="12" cy="134" r="6"/><circle cx="36" cy="134" r="6"/><circle cx="60" cy="134" r="6"/><circle cx="84" cy="134" r="6"/><circle cx="108" cy="134" r="6"/><circle cx="132" cy="134" r="6"/><circle cx="156" cy="134" r="6"/><circle cx="180" cy="134" r="6"/><circle cx="204" cy="134" r="6"/><circle cx="228" cy="134" r="6"/><circle cx="252" cy="134" r="6"/><circle cx="276" cy="134" r="6"/><circle cx="300" cy="134" r="6"/><circle cx="324" cy="134" r="6"/><circle cx="348" cy="134" r="6"/>
-      <circle cx="12" cy="158" r="6"/><circle cx="36" cy="158" r="6"/><circle cx="60" cy="158" r="6"/><circle cx="84" cy="158" r="6"/><circle cx="108" cy="158" r="6"/><circle cx="132" cy="158" r="6"/><circle cx="156" cy="158" r="6"/><circle cx="180" cy="158" r="6"/><circle cx="204" cy="158" r="6"/><circle cx="228" cy="158" r="6"/><circle cx="252" cy="158" r="6"/><circle cx="276" cy="158" r="6"/><circle cx="300" cy="158" r="6"/><circle cx="324" cy="158" r="6"/><circle cx="348" cy="158" r="6"/>
+      <circle cx="12" cy="34" r="3.2"/><circle cx="23" cy="34" r="3.2"/><circle cx="34" cy="34" r="3.2"/><circle cx="45" cy="34" r="3.2"/><circle cx="56" cy="34" r="3.2"/><circle cx="67" cy="34" r="3.2"/><circle cx="78" cy="34" r="3.2"/><circle cx="89" cy="34" r="3.2"/><circle cx="100" cy="34" r="3.2"/><circle cx="111" cy="34" r="3.2"/><circle cx="122" cy="34" r="3.2"/><circle cx="133" cy="34" r="3.2"/><circle cx="144" cy="34" r="3.2"/><circle cx="155" cy="34" r="3.2"/><circle cx="166" cy="34" r="3.2"/><circle cx="177" cy="34" r="3.2"/><circle cx="188" cy="34" r="3.2"/><circle cx="199" cy="34" r="3.2"/><circle cx="210" cy="34" r="3.2"/><circle cx="221" cy="34" r="3.2"/><circle cx="232" cy="34" r="3.2"/><circle cx="243" cy="34" r="3.2"/><circle cx="254" cy="34" r="3.2"/><circle cx="265" cy="34" r="3.2"/><circle cx="276" cy="34" r="3.2"/><circle cx="287" cy="34" r="3.2"/><circle cx="298" cy="34" r="3.2"/><circle cx="309" cy="34" r="3.2"/><circle cx="320" cy="34" r="3.2"/><circle cx="331" cy="34" r="3.2"/><circle cx="342" cy="34" r="3.2"/><circle cx="353" cy="34" r="3.2"/><circle cx="364" cy="34" r="3.2"/><circle cx="375" cy="34" r="3.2"/><circle cx="386" cy="34" r="3.2"/><circle cx="397" cy="34" r="3.2"/><circle cx="408" cy="34" r="3.2"/>
+      <circle cx="12" cy="47" r="3.2"/><circle cx="23" cy="47" r="3.2"/><circle cx="34" cy="47" r="3.2"/><circle cx="45" cy="47" r="3.2"/><circle cx="56" cy="47" r="3.2"/><circle cx="67" cy="47" r="3.2"/><circle cx="78" cy="47" r="3.2"/><circle cx="89" cy="47" r="3.2"/><circle cx="100" cy="47" r="3.2"/><circle cx="111" cy="47" r="3.2"/><circle cx="122" cy="47" r="3.2"/><circle cx="133" cy="47" r="3.2"/><circle cx="144" cy="47" r="3.2"/><circle cx="155" cy="47" r="3.2"/><circle cx="166" cy="47" r="3.2"/><circle cx="177" cy="47" r="3.2"/><circle cx="188" cy="47" r="3.2"/><circle cx="199" cy="47" r="3.2"/><circle cx="210" cy="47" r="3.2"/><circle cx="221" cy="47" r="3.2"/><circle cx="232" cy="47" r="3.2"/><circle cx="243" cy="47" r="3.2"/><circle cx="254" cy="47" r="3.2"/><circle cx="265" cy="47" r="3.2"/><circle cx="276" cy="47" r="3.2"/><circle cx="287" cy="47" r="3.2"/><circle cx="298" cy="47" r="3.2"/><circle cx="309" cy="47" r="3.2"/><circle cx="320" cy="47" r="3.2"/><circle cx="331" cy="47" r="3.2"/><circle cx="342" cy="47" r="3.2"/><circle cx="353" cy="47" r="3.2"/><circle cx="364" cy="47" r="3.2"/><circle cx="375" cy="47" r="3.2" fill="#f59e0b" stroke="#f59e0b"/><circle cx="386" cy="47" r="3.2"/><circle cx="397" cy="47" r="3.2"/><circle cx="408" cy="47" r="3.2"/>
+      <circle cx="12" cy="60" r="3.2"/><circle cx="23" cy="60" r="3.2"/><circle cx="34" cy="60" r="3.2"/><circle cx="45" cy="60" r="3.2"/><circle cx="56" cy="60" r="3.2"/><circle cx="67" cy="60" r="3.2"/><circle cx="78" cy="60" r="3.2"/><circle cx="89" cy="60" r="3.2"/><circle cx="100" cy="60" r="3.2"/><circle cx="111" cy="60" r="3.2"/><circle cx="122" cy="60" r="3.2"/><circle cx="133" cy="60" r="3.2"/><circle cx="144" cy="60" r="3.2"/><circle cx="155" cy="60" r="3.2"/><circle cx="166" cy="60" r="3.2"/><circle cx="177" cy="60" r="3.2"/><circle cx="188" cy="60" r="3.2"/><circle cx="199" cy="60" r="3.2"/><circle cx="210" cy="60" r="3.2"/><circle cx="221" cy="60" r="3.2"/><circle cx="232" cy="60" r="3.2"/><circle cx="243" cy="60" r="3.2"/><circle cx="254" cy="60" r="3.2"/><circle cx="265" cy="60" r="3.2"/><circle cx="276" cy="60" r="3.2"/><circle cx="287" cy="60" r="3.2"/><circle cx="298" cy="60" r="3.2"/><circle cx="309" cy="60" r="3.2"/><circle cx="320" cy="60" r="3.2"/><circle cx="331" cy="60" r="3.2"/><circle cx="342" cy="60" r="3.2"/><circle cx="353" cy="60" r="3.2"/><circle cx="364" cy="60" r="3.2"/><circle cx="375" cy="60" r="3.2"/><circle cx="386" cy="60" r="3.2"/><circle cx="397" cy="60" r="3.2"/><circle cx="408" cy="60" r="3.2"/>
+      <circle cx="12" cy="73" r="3.2"/><circle cx="23" cy="73" r="3.2"/><circle cx="34" cy="73" r="3.2"/><circle cx="45" cy="73" r="3.2"/><circle cx="56" cy="73" r="3.2"/><circle cx="67" cy="73" r="3.2"/><circle cx="78" cy="73" r="3.2"/><circle cx="89" cy="73" r="3.2"/><circle cx="100" cy="73" r="3.2"/><circle cx="111" cy="73" r="3.2"/><circle cx="122" cy="73" r="3.2"/><circle cx="133" cy="73" r="3.2"/><circle cx="144" cy="73" r="3.2"/><circle cx="155" cy="73" r="3.2"/><circle cx="166" cy="73" r="3.2"/><circle cx="177" cy="73" r="3.2"/><circle cx="188" cy="73" r="3.2"/><circle cx="199" cy="73" r="3.2"/><circle cx="210" cy="73" r="3.2"/><circle cx="221" cy="73" r="3.2"/><circle cx="232" cy="73" r="3.2"/><circle cx="243" cy="73" r="3.2"/><circle cx="254" cy="73" r="3.2"/><circle cx="265" cy="73" r="3.2"/><circle cx="276" cy="73" r="3.2"/><circle cx="287" cy="73" r="3.2"/><circle cx="298" cy="73" r="3.2"/><circle cx="309" cy="73" r="3.2"/><circle cx="320" cy="73" r="3.2"/><circle cx="331" cy="73" r="3.2"/><circle cx="342" cy="73" r="3.2"/><circle cx="353" cy="73" r="3.2"/><circle cx="364" cy="73" r="3.2"/><circle cx="375" cy="73" r="3.2"/><circle cx="386" cy="73" r="3.2"/><circle cx="397" cy="73" r="3.2"/><circle cx="408" cy="73" r="3.2"/>
+      <circle cx="12" cy="86" r="3.2"/><circle cx="23" cy="86" r="3.2"/><circle cx="34" cy="86" r="3.2"/><circle cx="45" cy="86" r="3.2"/><circle cx="56" cy="86" r="3.2"/><circle cx="67" cy="86" r="3.2"/><circle cx="78" cy="86" r="3.2"/><circle cx="89" cy="86" r="3.2"/><circle cx="100" cy="86" r="3.2"/><circle cx="111" cy="86" r="3.2"/><circle cx="122" cy="86" r="3.2"/><circle cx="133" cy="86" r="3.2"/><circle cx="144" cy="86" r="3.2"/><circle cx="155" cy="86" r="3.2"/><circle cx="166" cy="86" r="3.2"/><circle cx="177" cy="86" r="3.2"/><circle cx="188" cy="86" r="3.2"/><circle cx="199" cy="86" r="3.2"/><circle cx="210" cy="86" r="3.2"/><circle cx="221" cy="86" r="3.2"/><circle cx="232" cy="86" r="3.2"/><circle cx="243" cy="86" r="3.2"/><circle cx="254" cy="86" r="3.2"/><circle cx="265" cy="86" r="3.2"/><circle cx="276" cy="86" r="3.2"/><circle cx="287" cy="86" r="3.2"/><circle cx="298" cy="86" r="3.2"/><circle cx="309" cy="86" r="3.2"/><circle cx="320" cy="86" r="3.2"/><circle cx="331" cy="86" r="3.2"/><circle cx="342" cy="86" r="3.2"/><circle cx="353" cy="86" r="3.2"/><circle cx="364" cy="86" r="3.2"/><circle cx="375" cy="86" r="3.2"/><circle cx="386" cy="86" r="3.2"/><circle cx="397" cy="86" r="3.2"/><circle cx="408" cy="86" r="3.2"/>
+      <circle cx="12" cy="99" r="3.2"/><circle cx="23" cy="99" r="3.2"/><circle cx="34" cy="99" r="3.2"/><circle cx="45" cy="99" r="3.2"/><circle cx="56" cy="99" r="3.2"/><circle cx="67" cy="99" r="3.2" fill="#f59e0b" stroke="#f59e0b"/><circle cx="78" cy="99" r="3.2"/><circle cx="89" cy="99" r="3.2"/><circle cx="100" cy="99" r="3.2"/><circle cx="111" cy="99" r="3.2"/><circle cx="122" cy="99" r="3.2"/><circle cx="133" cy="99" r="3.2"/><circle cx="144" cy="99" r="3.2"/><circle cx="155" cy="99" r="3.2"/><circle cx="166" cy="99" r="3.2"/><circle cx="177" cy="99" r="3.2"/><circle cx="188" cy="99" r="3.2"/><circle cx="199" cy="99" r="3.2"/><circle cx="210" cy="99" r="3.2"/><circle cx="221" cy="99" r="3.2"/><circle cx="232" cy="99" r="3.2"/><circle cx="243" cy="99" r="3.2"/><circle cx="254" cy="99" r="3.2"/><circle cx="265" cy="99" r="3.2"/><circle cx="276" cy="99" r="3.2"/><circle cx="287" cy="99" r="3.2"/><circle cx="298" cy="99" r="3.2"/><circle cx="309" cy="99" r="3.2"/><circle cx="320" cy="99" r="3.2"/><circle cx="331" cy="99" r="3.2"/><circle cx="342" cy="99" r="3.2"/><circle cx="353" cy="99" r="3.2"/><circle cx="364" cy="99" r="3.2"/><circle cx="375" cy="99" r="3.2"/><circle cx="386" cy="99" r="3.2"/><circle cx="397" cy="99" r="3.2"/><circle cx="408" cy="99" r="3.2"/>
+      <circle cx="12" cy="112" r="3.2"/><circle cx="23" cy="112" r="3.2"/><circle cx="34" cy="112" r="3.2"/><circle cx="45" cy="112" r="3.2"/><circle cx="56" cy="112" r="3.2"/><circle cx="67" cy="112" r="3.2"/><circle cx="78" cy="112" r="3.2"/><circle cx="89" cy="112" r="3.2"/><circle cx="100" cy="112" r="3.2"/><circle cx="111" cy="112" r="3.2"/><circle cx="122" cy="112" r="3.2"/><circle cx="133" cy="112" r="3.2"/><circle cx="144" cy="112" r="3.2"/><circle cx="155" cy="112" r="3.2"/><circle cx="166" cy="112" r="3.2"/><circle cx="177" cy="112" r="3.2"/><circle cx="188" cy="112" r="3.2"/><circle cx="199" cy="112" r="3.2"/><circle cx="210" cy="112" r="3.2"/><circle cx="221" cy="112" r="3.2"/><circle cx="232" cy="112" r="3.2"/><circle cx="243" cy="112" r="3.2"/><circle cx="254" cy="112" r="3.2"/><circle cx="265" cy="112" r="3.2"/><circle cx="276" cy="112" r="3.2"/><circle cx="287" cy="112" r="3.2"/><circle cx="298" cy="112" r="3.2"/><circle cx="309" cy="112" r="3.2"/><circle cx="320" cy="112" r="3.2"/><circle cx="331" cy="112" r="3.2"/><circle cx="342" cy="112" r="3.2"/><circle cx="353" cy="112" r="3.2"/><circle cx="364" cy="112" r="3.2"/><circle cx="375" cy="112" r="3.2"/><circle cx="386" cy="112" r="3.2"/><circle cx="397" cy="112" r="3.2"/><circle cx="408" cy="112" r="3.2"/>
+      <circle cx="12" cy="125" r="3.2"/><circle cx="23" cy="125" r="3.2"/><circle cx="34" cy="125" r="3.2"/><circle cx="45" cy="125" r="3.2"/><circle cx="56" cy="125" r="3.2"/><circle cx="67" cy="125" r="3.2"/><circle cx="78" cy="125" r="3.2"/><circle cx="89" cy="125" r="3.2"/><circle cx="100" cy="125" r="3.2"/><circle cx="111" cy="125" r="3.2"/><circle cx="122" cy="125" r="3.2"/><circle cx="133" cy="125" r="3.2"/><circle cx="144" cy="125" r="3.2"/><circle cx="155" cy="125" r="3.2"/><circle cx="166" cy="125" r="3.2"/><circle cx="177" cy="125" r="3.2"/><circle cx="188" cy="125" r="3.2"/><circle cx="199" cy="125" r="3.2"/><circle cx="210" cy="125" r="3.2"/><circle cx="221" cy="125" r="3.2"/><circle cx="232" cy="125" r="3.2"/><circle cx="243" cy="125" r="3.2"/><circle cx="254" cy="125" r="3.2"/><circle cx="265" cy="125" r="3.2"/><circle cx="276" cy="125" r="3.2"/><circle cx="287" cy="125" r="3.2"/><circle cx="298" cy="125" r="3.2"/><circle cx="309" cy="125" r="3.2"/><circle cx="320" cy="125" r="3.2"/><circle cx="331" cy="125" r="3.2"/><circle cx="342" cy="125" r="3.2"/><circle cx="353" cy="125" r="3.2"/><circle cx="364" cy="125" r="3.2"/><circle cx="375" cy="125" r="3.2"/><circle cx="386" cy="125" r="3.2"/><circle cx="397" cy="125" r="3.2"/><circle cx="408" cy="125" r="3.2"/>
     </g>
-    <text x="380" y="86" fill="#2fd27a" font-size="46" font-weight="800">0</text>
-    <text x="380" y="112" fill="currentColor" font-size="14" opacity=".8">flagged</text>
-    <text x="380" y="134" fill="currentColor" font-size="13" opacity=".55">none filled in,</text>
-    <text x="380" y="151" fill="currentColor" font-size="13" opacity=".55">none accused</text>
+    <text x="442" y="72" fill="#f59e0b" font-size="46" font-weight="800">2</text>
+    <text x="442" y="98" fill="currentColor" font-size="14" opacity=".8">flagged</text>
+    <text x="442" y="120" fill="currentColor" font-size="13" opacity=".55">the two filled in,</text>
+    <text x="442" y="137" fill="currentColor" font-size="13" opacity=".55">out of two hundred and ninety-six</text>
 
-    <text x="0" y="196" fill="currentColor" font-size="12" font-weight="700" opacity=".75">WHAT CAN HONESTLY BE CLAIMED</text>
+    <text x="0" y="172" fill="currentColor" font-size="12" font-weight="700" opacity=".75">WHAT CAN HONESTLY BE CLAIMED</text>
     <line x1="12" y1="216" x2="620" y2="216" stroke="currentColor" stroke-opacity=".25" stroke-width="2"/>
-    <rect x="12" y="209" width="249" height="14" rx="7" fill="#f59e0b" fill-opacity=".28"/>
-    <circle cx="12" cy="216" r="6" fill="#2fd27a"/>
+    <rect x="24" y="209" width="134" height="14" rx="7" fill="#f59e0b" fill-opacity=".28"/>
+    <circle cx="53" cy="216" r="6" fill="#2fd27a"/>
+    <text x="53" y="202" fill="#2fd27a" font-size="12" font-weight="700" text-anchor="middle">0.7%</text>
     <text x="12" y="241" fill="currentColor" font-size="12" opacity=".75">0%</text>
-    <text x="222" y="241" fill="#f59e0b" font-size="12" font-weight="700">4.1%</text>
+    <text x="168" y="241" fill="#f59e0b" font-size="12" font-weight="700">2.4%</text>
     <text x="620" y="241" fill="currentColor" font-size="12" opacity=".55" text-anchor="end">10%</text>
   </svg>
   <figcaption>
-    None of the ninety was flagged. But <strong>zero out of ninety is not a rate of zero</strong>:
-    with a sample that size, the most anyone can honestly claim is that it is wrong
-    <strong>less than 4.1%</strong> of the time. That amber band is the difference between a
-    measurement and a promise.
+    Two of the 296 were flagged: <strong>0.7%</strong>. But two out of 296 is not exactly the
+    rate either: with a sample that size, the most anyone can honestly claim is that it is wrong
+    <strong>less than 2.4%</strong> of the time. That amber band is the difference between a
+    measurement and a promise. <strong>It is not zero, and that is the point</strong>: until
+    September this page showed a zero, because the corpus did not yet hold the people most likely
+    to be accused falsely.
   </figcaption>
 </figure>
 
 <h3>And it is not the same number for everybody</h3>
 <p>
-  Handing the pooled figure to everyone would be convenient and false. The corpus holds sixty-five
-  English texts and twenty-five Spanish ones, so what can be claimed about each language differs —
-  and in the tool, each reader is shown their own, never the average.
+  Handing the pooled figure to everyone would be convenient and false. The corpus holds
+  <strong>271 English texts and twenty-five Spanish ones</strong>, so what can be claimed about
+  each language differs — and in the tool, each reader is shown their own, never the average.
 </p>
 
 <figure>
-  <svg viewBox="0 0 640 140" role="img" aria-label="Bound by language: English 5.6 percent, Spanish 13.3 percent">
+  <svg viewBox="0 0 640 140" role="img" aria-label="Bound by language: English 2.7 percent, Spanish 13.3 percent">
     <text x="0" y="22" fill="currentColor" font-size="14" font-weight="600">English</text>
-    <text x="0" y="39" fill="currentColor" font-size="11.5" opacity=".55">65 texts</text>
+    <text x="0" y="39" fill="currentColor" font-size="11.5" opacity=".55">271 texts</text>
     <line x1="120" y1="26" x2="620" y2="26" stroke="currentColor" stroke-opacity=".2" stroke-width="2"/>
-    <rect x="120" y="19" width="187" height="14" rx="7" fill="#f59e0b" fill-opacity=".3"/>
-    <text x="317" y="31" fill="#f59e0b" font-size="13" font-weight="700">5.6%</text>
+    <rect x="120" y="19" width="90" height="14" rx="7" fill="#f59e0b" fill-opacity=".3"/>
+    <text x="220" y="31" fill="#f59e0b" font-size="13" font-weight="700">2.7%</text>
 
     <text x="0" y="80" fill="currentColor" font-size="14" font-weight="600">Spanish</text>
     <text x="0" y="97" fill="currentColor" font-size="11.5" opacity=".55">25 texts</text>
@@ -454,14 +478,23 @@ body:has(#en:checked) .only-en{display:block}
   fashionable that month. A tool that flags nothing has a perfect error rate.
 </p>
 <p>
-  The ninety texts are <strong>published articles, not student work</strong>. A first-year essay
-  does not read like a peer-reviewed paper, and that difference is not measured here.
+  <strong>It does include student work, and that is the part that matters most to you.</strong>
+  Of the 296 texts, <strong>206 are classroom essays</strong> written by adults learning English.
+  That is precisely the group detectors are accused of getting wrong most often, and here it is the
+  group that fares worst: it sits highest of any group in every column. At a threshold of 25 out of
+  100, nine of them were flagged. <strong>That is why the boundary is 30 and not 25</strong> — it
+  moved once we knew who it was hurting.
+</p>
+<p>
+  What is still unmeasured is the <strong>student essay in Spanish</strong>: the twenty-five Spanish
+  texts are Wikipedia revisions from a single source. There this tool knows less, and it says so
+  rather than lending one language a figure it measured in another.
 </p>
 <div class="quote">
-  And one worth knowing before you look at any score: the signal that fires most often on human
-  writing is <b>uniform sentence rhythm</b> — it appears in <b>27.8%</b> of the human texts we
-  measured. If the evidence against a piece of work leans mostly on that, it is worth less. The
-  tool says so on every report, by name.
+  And one worth knowing before you look at any score: the signals that fire most often on human
+  writing say almost nothing. <b>Uniform sentence rhythm</b> appears in <b>32.1%</b> of the human
+  texts we measured, and the word "just" in <b>34.8%</b>. If the evidence against a piece of work
+  leans mostly on those, it is worth less. The tool says so on every report, by name.
 </div>
 
 <h2>Why trust this one and not another?</h2>
@@ -516,13 +549,13 @@ body:has(#en:checked) .only-en{display:block}
 <footer>
   <p class="only-es">
     Signs of AI Writing · PeopleWorks — Pedro Hernández · Código abierto (MIT).
-    Cifras medidas el 5 de agosto de 2026 sobre el motor 0.4.0, con noventa textos publicados
-    antes de que existieran los modelos generativos.
+    Cifras medidas el 7 de septiembre de 2026 sobre el motor 0.7.0, con 296 textos escritos
+    antes de 2022.
   </p>
   <p class="only-en">
     Signs of AI Writing · PeopleWorks — Pedro Hernández · Open source (MIT).
-    Figures measured on 5 August 2026 against engine 0.4.0, over ninety texts published before
-    generative models existed.
+    Figures measured on 7 September 2026 against engine 0.7.0, over 296 texts written before
+    2022.
   </p>
 </footer>
 

--- a/tests/SignsOfAI.Core.Tests/ChatResidueTests.cs
+++ b/tests/SignsOfAI.Core.Tests/ChatResidueTests.cs
@@ -15,7 +15,7 @@ namespace SignsOfAI.Core.Tests;
 ///
 /// That is also why this batch was admissible when most of the pattern set it came from was not.
 /// The rules were screened against the calibration corpus first — 249,455 words of English and
-/// 39,712 of Spanish, all published before generative models existed — and every one of them scored
+/// 39,712 of Spanish, all published before 2022 — and every one of them scored
 /// zero. Re-running the calibration afterwards left the published false-positive rate untouched,
 /// which is the point: they cost nothing to carry.
 ///

--- a/tests/SignsOfAI.Core.Tests/WhyPageTests.cs
+++ b/tests/SignsOfAI.Core.Tests/WhyPageTests.cs
@@ -1,0 +1,137 @@
+using System.Text.RegularExpressions;
+using SignsOfAI.Core.Calibration;
+using Xunit;
+
+namespace SignsOfAI.Core.Tests;
+
+/// <summary>
+/// <c>why.html</c> is the page README line 15 sends teachers to first, and it has no build step
+/// behind it on purpose — it must open from a downloads folder years from now on a machine that
+/// has never heard of this project. The cost of that choice is that its figures are typed by hand,
+/// and a comment asking the next person to remember is not a guarantee.
+///
+/// It was not. The page sat from 5 August through two corpus changes still showing "ninety texts"
+/// and a green zero, while the project's own published rate had stopped being zero — on the one
+/// page whose entire argument is that this project tells you how often it is wrong.
+///
+/// So these tests read the same <c>published-calibration.json</c> the engine ships and require the
+/// page to agree with it. When the calibration moves, this fails by name and says what to redraw.
+/// </summary>
+public class WhyPageTests
+{
+    private static readonly string Page = File.ReadAllText(PagePath());
+
+    /// <summary>The snapshot the engine ships. A build without one is a broken build, not a pass.</summary>
+    private static PublishedCalibration Shipped =>
+        PublishedCalibration.Current ?? throw new InvalidOperationException(
+            "The build carries no published calibration, so why.html cannot be checked against it.");
+
+    private static string PagePath()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "src")))
+            dir = dir.Parent;
+
+        Assert.NotNull(dir);
+        return Path.Combine(dir!.FullName, "src", "SignsOfAI.Web", "wwwroot", "why.html");
+    }
+
+    // The page writes Spanish figures with a comma and English ones with a dot, so every check
+    // wants both spellings and both must be present — one language quietly going stale is the
+    // failure this guards.
+    private static void AssertBothLanguagesSay(string english, string spanish, string what)
+    {
+        Assert.True(Page.Contains(english, StringComparison.Ordinal),
+            $"why.html no longer states {what} in English ({english}). The calibration moved; redraw the page.");
+        Assert.True(Page.Contains(spanish, StringComparison.Ordinal),
+            $"why.html no longer states {what} in Spanish ({spanish}). The calibration moved; redraw the page.");
+    }
+
+    [Fact]
+    public void The_corpus_size_on_the_page_is_the_corpus_size_that_shipped()
+    {
+        int texts = Shipped.Texts;
+
+        AssertBothLanguagesSay($"{texts} HUMAN TEXTS", $"{texts} TEXTOS HUMANOS", "the corpus size in its chart");
+        AssertBothLanguagesSay($"{texts} texts written before", $"{texts} textos escritos antes", "the corpus size in its prose");
+    }
+
+    [Fact]
+    public void The_dot_chart_draws_one_circle_per_text_and_fills_the_flagged_ones()
+    {
+        // Both halves of the page carry the same chart, so every count here is doubled.
+        int texts = Shipped.Texts;
+        int flagged = Shipped.FlaggedAtThreshold;
+
+        int circles = Regex.Matches(Page, @"<circle cx=""\d+"" cy=""\d+"" r=""3\.2""").Count;
+        int filled = Regex.Matches(Page, @"<circle cx=""\d+"" cy=""\d+"" r=""3\.2"" fill=""#f59e0b""").Count;
+
+        Assert.Equal(texts * 2, circles);
+        Assert.Equal(flagged * 2, filled);
+    }
+
+    [Fact]
+    public void The_upper_bound_drawn_is_the_upper_bound_published()
+    {
+        // The bound the page may claim is the one at the recommended threshold, never a better one
+        // measured at a stricter cut. Printing the best bound beside the recommended threshold is
+        // the defect the committee caught in the evidence report on 1 September.
+        string en = (Shipped.RateHigh * 100).ToString("0.0");
+        AssertBothLanguagesSay($"less than {en}%", $"menos del {en.Replace('.', ',')} %", "the upper bound of its interval");
+    }
+
+    [Fact]
+    public void The_measured_rate_drawn_is_the_measured_rate_published()
+    {
+        var c = Shipped;
+        string rate = (c.FlaggedAtThreshold / (double)c.Texts * 100).ToString("0.0");
+
+        AssertBothLanguagesSay($">{rate}%<", $">{rate.Replace('.', ',')} %<", "the rate it actually measured");
+    }
+
+    [Fact]
+    public void The_english_bar_shows_the_bound_at_the_threshold_not_the_best_one()
+    {
+        var english = Shipped.Languages.Single(l => l.Language == "en");
+        Assert.NotNull(english.RateHighAtThreshold);
+
+        string atThreshold = (english.RateHighAtThreshold!.Value * 100).ToString("0.0");
+        string best = (english.BestBound * 100).ToString("0.0");
+
+        AssertBothLanguagesSay($">{atThreshold}%<", $">{atThreshold.Replace('.', ',')} %<",
+            "English's bound at the recommended threshold");
+
+        // And it must not quietly show the flattering one instead.
+        Assert.DoesNotContain($"font-weight=\"700\">{best}%<", Page, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_page_names_the_engine_that_produced_its_figures()
+    {
+        string engine = Shipped.Engine;
+
+        AssertBothLanguagesSay($"engine {engine}", $"motor {engine}", "the engine version its figures came from");
+    }
+
+    [Fact]
+    public void Nothing_on_the_page_still_claims_a_rate_of_zero()
+    {
+        // The claim that survived six days after it stopped being true.
+        Assert.DoesNotContain("zero out of ninety", Page, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("cero de noventa", Page, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void The_page_still_asks_nothing_of_any_server()
+    {
+        // Its own first rule: a page arguing that student work never leaves your machine cannot
+        // itself fetch from somebody else's. Guarded here because a redraw is when it would slip.
+        Assert.DoesNotContain("<script", Page, StringComparison.OrdinalIgnoreCase);
+        foreach (Match m in Regex.Matches(Page, @"(?:src|href)=""(https?:)?//([^""]+)""", RegexOptions.IgnoreCase))
+        {
+            string host = m.Groups[2].Value;
+            bool allowed = host.StartsWith("github.com/peopleworks/", StringComparison.OrdinalIgnoreCase);
+            Assert.True(allowed, $"why.html would fetch from {host}; it must ask nothing of any server.");
+        }
+    }
+}

--- a/tools/SignsOfAI.Calibration/Fetch.cs
+++ b/tools/SignsOfAI.Calibration/Fetch.cs
@@ -10,7 +10,7 @@ namespace SignsOfAI.Calibration;
 /// Assembles a corpus of writing that is known to be human.
 ///
 /// "Known" is doing real work here, and it rests on one fact rather than on a classifier: every text
-/// collected was published before generative models could have written it. A paper with a 2019 DOI
+/// collected was published before 2022, so no generative model could have written it. A 2019 DOI
 /// and a Wikipedia revision stamped 2021 were not produced by something that did not exist. No
 /// detector can offer a guarantee that strong about anything, which is precisely why the corpus has
 /// to come from dates and not from judgement.
@@ -87,7 +87,7 @@ public static partial class Fetch
     ];
 
     /// <summary>
-    /// Open-access research articles published well before generative models, from PLOS.
+    /// Open-access research articles published well before 2022, from PLOS.
     ///
     /// Academic prose is not a student essay and the report says so. It is, however, the closest
     /// freely licensed writing to what a teacher actually reads, and it comes with author
@@ -194,7 +194,7 @@ public static partial class Fetch
     // ---- Wikipedia -------------------------------------------------------------------------------
 
     /// <summary>
-    /// Article prose as it stood before generative models, taken from the revision history.
+    /// Article prose as it stood before 2022, taken from the revision history.
     ///
     /// This is the only route found that yields substantial Spanish prose that is provably pre-model,
     /// openly licensed and machine-fetchable — and Spanish is the half of this project that nobody
@@ -261,7 +261,7 @@ public static partial class Fetch
                         Url = $"https://{language}.wikipedia.org/w/index.php?oldid={revid}",
                         File = file,
                         Sha256 = CorpusManifest.HashText(text),
-                        Note = $"Revision of \"{title}\" as of {stamp}, before generative models.",
+                        Note = $"Revision of \"{title}\" as of {stamp}, before 2022.",
                     });
 
                     Console.WriteLine($"  {entries.Count,3}. {id}  {stamp[..10]}  {CountWords(text),6:N0} words  {Shorten(title)}");

--- a/tools/SignsOfAI.Calibration/ParaphraseReport.cs
+++ b/tools/SignsOfAI.Calibration/ParaphraseReport.cs
@@ -140,7 +140,7 @@ public static class ParaphraseReport
         sb.AppendLine($"- **Run** {generatedOn}");
         sb.AppendLine();
         sb.AppendLine(
-            "Every human half was published before generative models existed, which is the whole basis " +
+            "Every human half was published before 2022, which is the whole basis " +
             "for calling it human and the same basis the calibration page rests on. Both halves are the " +
             "same passage at roughly the same length, so the comparison is within a text rather than " +
             "between two populations: no collection of machine-written prose was assembled, and none " +


### PR DESCRIPTION
`README.md:15` is the first link in the file — **"Are you a teacher? Start here →"** — and it points at `why.html`, which is live.

| The page said | The project publishes |
|---|---|
| **ninety texts** | 296, since 1 September |
| **zero flagged** — a green `0`, 46px | **2 of 296** |
| less than **4.1%** | **2.4%** |
| engine **0.4.0** | **0.7.0** |
| uniform rhythm in **27.8%** | **32.1%** |

Nothing on it was a lie: the footer dates every figure to 5 August. But the headline argument a teacher reads is a green zero, on the page whose entire purpose is that this project publishes how often it is wrong. **The 1 September work existed to say the rate had stopped being zero.** This page never heard.

## It carried its own trigger, and the trigger did nothing

From a comment written in August, still in the file:

> Every figure comes from `published-calibration.json`… **If that file changes, this page is stale and must be regenerated by hand** — there is no build step behind it, deliberately.

That file changed twice. Asking the next person to remember is not a guarantee.

`WhyPageTests` now reads the same `published-calibration.json` the engine ships and requires the page to agree — **in both languages**, since one half going stale alone is the likelier failure. **Seven of its eight guards fail against the page exactly as it is live right now.** The eighth is the "asks nothing of any server" rule, which was already true and is guarded because a redraw is when it would slip.

## Redrawn, not retyped

- The dot chart is **296 circles with two filled**, not ninety with none.
- The interval band runs **0.2–2.4% around a measured 0.7%**, not 4.1% around zero. Rendered and inspected in a browser; a label collision found that way and fixed.
- The English bar shows **2.7% — the bound at the recommended threshold**, not the 1.4% best bound. That substitution is the exact defect the committee caught in the evidence report on 1 September, and a guard here refuses it explicitly.

## The best change is a paragraph that inverted

It used to concede that the corpus was *"published articles, not student work"* and that the difference *"is not measured here"*. It is measured now: **206 of the 296 are classroom essays by adults learning English** — the group that fares worst in every column, and the reason the boundary is 30 rather than 25. What is still unmeasured is the student essay **in Spanish**, and the page says that instead.

For the audience this page exists to reach, that is the strongest thing the project can currently say, and it was sitting unsaid.

## Also #78, everywhere outside `Docs/Blog`

*"before generative models existed"* overclaims — GPT-3 is 2020. The worst instance was in `Docs/Calibration/corpus.json`, where the note sat on **fifty Wikipedia revisions from 2021**: the exact case the sentence does not cover. Fixed in `Fetch.cs` so it stays fixed, plus the MCP report tool, four `Core` comments, `PARAPHRASE.md` and a test.

The blog articles keep their wording. They are dated studies, per the standing policy.

432 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015PEbbiYSNPw7jE3LrPNhyF