### PR TITLE
0.8.0 — the reader's language, and a front door for the skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "signs-of-ai",
   "description": "Measure a text for the signs of AI writing and read back the evidence — offline, EN/ES, with the tool's own false-positive rate attached.",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "author": {
     "name": "Pedro Hernández — PeopleWorks",
     "url": "https://github.com/peopleworks"

--- a/src/SignsOfAI.Cli/SignsOfAI.Cli.csproj
+++ b/src/SignsOfAI.Cli/SignsOfAI.Cli.csproj
@@ -13,7 +13,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>signsofai</ToolCommandName>
     <PackageId>SignsOfAI.Cli</PackageId>
-    <Version>0.7.1</Version>
+    <Version>0.8.0</Version>
     <Authors>Pedro Hernández (PeopleWorks)</Authors>
     <Company>PeopleWorks</Company>
     <Description>CLI to detect the signs of AI writing (English &amp; Spanish) and recommend fixes — lint your prose in CI.</Description>

--- a/src/SignsOfAI.Core/SignsOfAI.Core.csproj
+++ b/src/SignsOfAI.Core/SignsOfAI.Core.csproj
@@ -10,7 +10,7 @@
 
     <!-- Publishable as a library so others can embed the engine. -->
     <PackageId>SignsOfAI.Core</PackageId>
-    <Version>0.7.1</Version>
+    <Version>0.8.0</Version>
     <Authors>Pedro Hernández (PeopleWorks)</Authors>
     <Company>PeopleWorks</Company>
     <Description>The engine behind Signs of AI Writing: detects the stylometric tells of AI-generated text (English &amp; Spanish) — overused vocabulary, rhetorical crutches, syntactic tells and burstiness — and returns an actionable fix for each finding. No external dependencies.</Description>

--- a/src/SignsOfAI.Mcp/.mcp/server.json
+++ b/src/SignsOfAI.Mcp/.mcp/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.peopleworks/signs-of-ai",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "title": "Signs of AI Writing",
   "description": "AI-writing detection (EN/ES) that shows the evidence: named tells, hidden characters, citations.",
   "packages": [
@@ -9,7 +9,7 @@
       "registryType": "nuget",
       "registryBaseUrl": "https://api.nuget.org/v3/index.json",
       "identifier": "SignsOfAI.Mcp",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/SignsOfAI.Mcp/SignsOfAI.Mcp.csproj
+++ b/src/SignsOfAI.Mcp/SignsOfAI.Mcp.csproj
@@ -12,7 +12,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>signsofai-mcp</ToolCommandName>
     <PackageId>SignsOfAI.Mcp</PackageId>
-    <Version>0.7.1</Version>
+    <Version>0.8.0</Version>
     <Authors>Pedro Hernández (PeopleWorks)</Authors>
     <Company>PeopleWorks</Company>
     <Description>Model Context Protocol (MCP) server for Signs of AI Writing. Exposes the engine as tools — analyze text for AI tells, check originality between documents, search the sign catalog, extract distinctive phrases, and (optionally, via the hosted API) measure perplexity and find paraphrases — to Claude Desktop and any MCP client.</Description>

--- a/src/SignsOfAI.UI/Services/DesktopRelease.cs
+++ b/src/SignsOfAI.UI/Services/DesktopRelease.cs
@@ -20,7 +20,7 @@ namespace SignsOfAI.UI.Services;
 public static class DesktopRelease
 {
     /// <summary>The published version, without the <c>desktop-v</c> prefix its tag carries.</summary>
-    public const string Version = "0.7.1";
+    public const string Version = "0.8.0";
 
     /// <summary>
     /// The .zip itself, so the button downloads rather than starting a scavenger hunt through a


### PR DESCRIPTION
Bumps every version declaration to **0.8.0**. Nothing else changes.

**Minor, not a patch.** `AiWritingAnalyzer.Analyze` gains an optional `readerLanguage` parameter, the CLI gains `--reader-lang`, and the evidence report can be written in Spanish **at all** for the first time.

## The seven declarations

Enforced by `ReleaseVersionTests` (added yesterday in #97) rather than by remembering:

| | |
|---|---|
| `SignsOfAI.Core.csproj` · `SignsOfAI.Cli.csproj` · `SignsOfAI.Mcp.csproj` | NuGet |
| `.mcp/server.json` | **twice** — the registry rejects them out of step, after NuGet has published |
| `DesktopRelease.Version` | the download page; `desktop-release.yml` refuses a tag that disagrees |
| `.claude-plugin/plugin.json` | the plugin directory — the one that said 0.4.0 since August |

Verified after bumping, not assumed: `signsofai --version` prints **0.8.0** and a generated report carries **`SignsOfAI 0.8.0`**. This project told everyone it was 0.1.0 for seven releases.

**485 tests** across both solutions.

---

## Release notes, ready to paste

### `v0.8.0` — NuGet + engine

**The reader's language.** The character scan and the citation cross-check used to speak the *analysed text's* language, so an English teacher opening a Spanish essay got the panel's chrome in English and its body in Spanish. Both are facts about the file addressed to whoever is reading, so they now follow the reader (#88). `Analyze()` takes an optional `readerLanguage`; null follows the text, so existing callers are unchanged.

**A Spanish evidence report, at last.** The CLI never set `InterfaceLanguage`, so `report.es.json` was unreachable from a command line — and the file itself carried only **39 of 76 blocks**, so the report came out half English behind fallback markers. Both fixed; `--reader-lang <en|es>` is the new option (#77).

**Turkish is not a disguise.** `U+0131` was flagged as a lookalike, so *Fazıl*, *Kıbrıs*, *Rıza* and *Komandoları* were reported as artifacts in a Spanish article about a Turkish organisation. The one check this project presents as a fact was stating a false one (#62).

**The advice takes its own advice.** 49 strings reworded: the rule packs delivered their guidance with the mark one of the rules is about, at 2.1 em-dashes per 100 words — Medium severity by our own instrument (#82).

**Corrections.** The teacher package was quoting a corpus of ninety with none flagged; it now reads the shipped calibration (#78). The README's MCP table had lost `write_report` (#94).

### `desktop-v0.8.0`

Everything above, plus **the Word add-in page**: `v0.7.1` was tagged at 15:42 on 7 September and the add-in merged after 18:38, so this is the first desktop build that carries `/word-addin`. The agent skill also gets its own page at `/skill`.

### After merging

1. `gh release create v0.8.0` → `nuget.yml` publishes Core, Cli and Mcp
2. `gh release create desktop-v0.8.0` → builds the zip and prints its checksum for the notes
3. The MCP registry is still the manual step — publish **after** NuGet has indexed 0.8.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015PEbbiYSNPw7jE3LrPNhyF
